### PR TITLE
build: apple notarization

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,16 @@ on:
         description: Maximum amount of parallel matrix build strategy runners, defaults to 10
         default: 10
         type: number
+      do-upload-game-binaries:
+        required: false
+        description: Set to true when generated game binaries should be uploaded to GitHub
+        default: false
+        type: boolean
+      do-upload-debug-symbols:
+        required: false
+        description: Set to true when generated debug symbols should be uploaded to GitHub
+        default: false
+        type: boolean
     secrets:
       UNITY_EMAIL: 
         required: true
@@ -151,23 +161,24 @@ jobs:
           versioning: Semantic
           buildName: CommunityProject
           customParameters: ${{ inputs.custom-parameters }}
-      
-      # We need to create a TAR archive before uploading due to possible permission loss
-      # See: 
-      #   - https://github.com/actions/upload-artifact#permission-loss
-      #   - https://github.com/game-ci/unity-actions/issues/152
-      - name: Create TAR archive
-        if: startsWith(matrix.os, 'macos-')
-        run: |
-          tar -czf Build-${{ github.run_id }}-${{ matrix.target-platform }}.tar ${{ matrix.target-platform }}
-          mv  Build-${{ github.run_id }}-${{ matrix.target-platform }}.tar ${{ matrix.target-platform }}
-          find . -not -name '*.tar' -delete
-        shell: bash
-        working-directory: build
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
+        name: Upload Game Binaries
+        if: inputs.do-upload-game-binaries
         with:
           name: Build-${{ github.run_id }}-${{ matrix.target-platform }}
-          path: build/${{ matrix.target-platform }}
+          path: | 
+            build/${{ matrix.target-platform }}
+            !build/${{ matrix.target-platform }}/*ButDontShipItWithYourGame
+            !build/${{ matrix.target-platform }}/*DoNotShip
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v3
+        name: Upload Debug Symbols
+        if: inputs.do-upload-debug-symbols
+        with:
+          name: Build-${{ github.run_id }}-${{ matrix.target-platform }}-Debug-Symbols
+          path: |
+            build/${{ matrix.target-platform }}/*ButDontShipItWithYourGame
+            build/${{ matrix.target-platform }}/*DoNotShip
           if-no-files-found: error
     strategy:
       fail-fast: ${{ inputs.fail-fast }}
@@ -177,12 +188,12 @@ jobs:
           - 2021.3.9f1
         os:
           - windows-2019
-          - macos-latest
+          - macos-12
           - ubuntu-latest
         include:
           - os: windows-2019
             target-platform: StandaloneWindows64
-          - os: macos-latest
+          - os: macos-12
             target-platform: StandaloneOSX
           - os: ubuntu-latest
             target-platform: StandaloneLinux64

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -29,3 +29,17 @@ jobs:
       UNITY_PASSWORD: ${{ secrets.UNITY_PERSONAL_PASSWORD }}
     with:
       do-test: true
+      do-upload-game-binaries: true
+      do-upload-debug-symbols: true
+
+  notarize:
+    needs: build
+    name: Notarize the macOS build
+    uses: ./.github/workflows/notarization.yml
+    secrets:
+      APPLE_CERTIFICATE_DATA: ${{ secrets.APPLE_CERTIFICATE_DATA }}
+      APPLE_CERTIFICATE_PASSPHRASE: ${{ secrets.APPLE_CERTIFICATE_PASSPHRASE }}
+      APPLE_TEAM_NAME: ${{ secrets.APPLE_TEAM_NAME }}
+      APPLE_NOTARIZATION_USERNAME: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+      APPLE_NOTARIZATION_PASSWORD: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+        

--- a/.github/workflows/notarization.yml
+++ b/.github/workflows/notarization.yml
@@ -1,0 +1,88 @@
+# Reusable workflow for notarizing the macOS build
+
+name: Apple App Notarization
+
+on: 
+  workflow_call:
+    inputs:
+      xcode-version:
+        required: false 
+        description: The XCode version to use, defaults to 14
+        default: 14
+        type: string
+    secrets:
+      APPLE_CERTIFICATE_DATA:
+        required: true
+      APPLE_CERTIFICATE_PASSPHRASE:
+        required: true  
+      APPLE_TEAM_NAME:
+        required: true
+      APPLE_NOTARIZATION_USERNAME:
+        required: true
+      APPLE_NOTARIZATION_PASSWORD:
+        required: true
+  
+jobs: 
+  notarize:
+    runs-on: macos-12
+    timeout-minutes: 15 # should be enough for notarization
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Debug List
+        run: ls -R
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v3
+        with:
+          name: Build-${{ github.run_id }}-StandaloneOSX
+          path: Build-${{ github.run_id }}-StandaloneOSX
+      - name: Select XCode Version ${{ inputs.xcode-version }}
+        uses: devbotsxyz/xcode-select@main
+        with:
+          version: ${{ inputs.xcode-version }}
+      - name: Generate random keychain password
+        id: password
+        run: |
+          random_password=$(openssl rand -base64 64)
+          echo "::add-mask::$random_password"
+          echo "::set-output name=value::$random_password"
+      - name: Import certificate
+        uses: devbotsxyz/import-signing-certificate@main
+        with:
+          certificate-data: ${{ secrets.APPLE_CERTIFICATE_DATA }}
+          certificate-passphrase: ${{ secrets.APPLE_CERTIFICATE_PASSPHRASE }}
+          keychain-password: ${{ steps.password.outputs.value }}
+          keychain-name: BoundfoxStudiosTemporaryKeychain
+      - name: Copy .entitlements file
+        run: cp build-resources/macOS/CommunityProject.entitlements Build-${{ github.run_id }}-StandaloneOSX
+      - name: Fix permissions
+        run: chmod -R a+xr CommunityProject.app
+        working-directory: Build-${{ github.run_id }}-StandaloneOSX
+      - name: Sign
+        run: codesign --deep --force --verify --verbose --timestamp --options runtime --entitlements "CommunityProject.entitlements" --sign "${{ secrets.APPLE_TEAM_NAME }}" CommunityProject.app
+        working-directory: Build-${{ github.run_id }}-StandaloneOSX
+      - name: Notarize
+        uses: devbotsxyz/xcode-notarize@v1
+        with:
+          product-path: Build-${{ github.run_id }}-StandaloneOSX/CommunityProject.app
+          appstore-connect-username: ${{ secrets.APPLE_NOTARIZATION_USERNAME }}
+          appstore-connect-password: ${{ secrets.APPLE_NOTARIZATION_PASSWORD }}
+      - name: Staple
+        uses: devbotsxyz/xcode-staple@v1
+        with:
+          product-path: Build-${{ github.run_id }}-StandaloneOSX/CommunityProject.app
+      # We need to create a TAR archive before uploading due to possible permission loss
+      # See: 
+      #   - https://github.com/actions/upload-artifact#permission-loss
+      #   - https://github.com/game-ci/unity-actions/issues/152
+      - name: Create TAR archive
+        run: |
+          rm Build-${{ github.run_id }}-StandaloneOSX/CommunityProject.entitlements
+          tar -czf Build-${{ github.run_id }}-StandaloneOSX.tar Build-${{ github.run_id }}-StandaloneOSX
+        shell: bash
+      - uses: actions/upload-artifact@v2
+        with:
+          name: Build-${{ github.run_id }}-StandaloneOSX
+          path: Build-${{ github.run_id }}-StandaloneOSX.tar
+          if-no-files-found: error

--- a/build-resources/macOS/CommunityProject.entitlements
+++ b/build-resources/macOS/CommunityProject.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+       <key>com.apple.security.cs.disable-library-validation</key>
+       <true/>
+       <key>com.apple.security.cs.disable-executable-page-protection</key>
+       <true/>
+    </dict>
+</plist>


### PR DESCRIPTION
**Beschreibung**
Erweitert die GitHub Actions um die Apple Notarization, die für macOS benötigt wird, um Apps außerhalb vom App Store zu deployen. Wird erst relevant, wenn wir's in Steam reinwerfen, aber so ist's schon mal drin zum Erfahrung sammeln, ob alles passt.

fixes #18 

## Checkliste
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [x] Aufgabe verlinkt (falls nicht, PR editieren)
- [ ] Tests geschrieben (nur relevant für Code-Änderungen)
- [ ] Dokumentation aktualisiert (nur relevant für System-Entwicklungen)

## PR Typ
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [ ] Bugfix
- [ ] Feature
- [ ] 3D-Modell
- [ ] 2D-Arbeit
- [ ] Sound-Effekte
- [ ] Musik
- [ ] Dokumentation
- [x] Sonstiges, bitte beschreiben: Build-Anpassung
