### PR TITLE
feat: use addressables in edit mode for PrefabManager

### DIFF
--- a/CommunityProject/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset
+++ b/CommunityProject/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset
@@ -1,0 +1,27 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7e3976da977cb49238499ea3b4c237ae, type: 3}
+  m_Name: ProfileDataSourceSettings
+  m_EditorClassIdentifier: 
+  profileGroupTypes:
+  - m_GroupTypePrefix: Built-In
+    m_Variables:
+    - m_Suffix: BuildPath
+      m_Value: '[UnityEngine.AddressableAssets.Addressables.BuildPath]/[BuildTarget]'
+    - m_Suffix: LoadPath
+      m_Value: '{UnityEngine.AddressableAssets.Addressables.RuntimePath}/[BuildTarget]'
+  - m_GroupTypePrefix: Editor Hosted
+    m_Variables:
+    - m_Suffix: BuildPath
+      m_Value: ServerData/[BuildTarget]
+    - m_Suffix: LoadPath
+      m_Value: http://[PrivateIpAddress]:[HostingServicePort]

--- a/CommunityProject/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset.meta
+++ b/CommunityProject/Assets/AddressableAssetsData/ProfileDataSourceSettings.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b8ac0b79a46a64ae98b6347ff9d64bc4
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CommunityProject/Assets/_Game/Scripts/Editor/BoundfoxStudios.CommunityProject.Editor.asmdef
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/BoundfoxStudios.CommunityProject.Editor.asmdef
@@ -2,7 +2,11 @@
     "name": "BoundfoxStudios.CommunityProject.Editor",
     "rootNamespace": "BoundfoxStudios.CommunityProject.Editor",
     "references": [
-        "GUID:a69fcba4d4eac4e8ca4c773e52725894"
+        "GUID:a69fcba4d4eac4e8ca4c773e52725894",
+        "GUID:9e24947de15b9834991c9d8411ea37cf",
+        "GUID:84651a3751eca9349aac36a66bba901b",
+        "GUID:f51ebe6a0ceec4240a699833d6309b23",
+        "GUID:593a5b492d29ac6448b1ebf7f035ef33"
     ],
     "includePlatforms": [
         "Editor"

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/EditorPrefabManagerMenus.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/EditorPrefabManagerMenus.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus
 	public static class EditorPrefabManagerMenus
 	{
 		[MenuItem(Constants.MenuNames.MenuName + "/Select PrefabManager", priority = 0)]
-		private static void PingPrefabManager()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid PingPrefabManagerAsync()
 		{
-			PrefabManager.SafeInvoke(prefabManager => Selection.activeObject = prefabManager);
+			await PrefabManager.SafeInvokeAsync(prefabManager => Selection.activeObject = prefabManager);
 		}
 	}
 }

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Cameras.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Cameras.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 	public static partial class Prefabs
 	{
 		[MenuItem(Constants.MenuNames.GameObjectMenus.Lights + "/Sun", priority = LightsMenuPriority)]
-		private static void CreateSun()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid CreateSunAsync()
 		{
-			SafeInstantiate(prefabManager => prefabManager.Lights.Sun);
+			await SafeInstantiateAsync(prefabManager => prefabManager.Lights.Sun);
 		}
 	}
 }

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Canvas.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Canvas.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 	public static partial class Prefabs
 	{
 		[MenuItem(Constants.MenuNames.GameObjectMenus.UI + "/Canvas", priority = UIMenuPriority * 2)]
-		private static void CreateCanvas()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid CreateCanvasAsync()
 		{
-			SafeInstantiate(prefabManager => prefabManager.Canvas);
+			await SafeInstantiateAsync(prefabManager => prefabManager.Canvas);
 		}
 	}
 }

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Editor.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Editor.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 	public static partial class Prefabs
 	{
 		[MenuItem(Constants.MenuNames.GameObjectMenus.Editor + "/EditorColdStartup", priority = EditorMenuPriority)]
-		private static void CreateEditorColdStartup()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid CreateEditorColdStartupAsync()
 		{
-			SafeInstantiate(prefabManager => prefabManager.Editor.EditorColdStartup);
+			await SafeInstantiateAsync(prefabManager => prefabManager.Editor.EditorColdStartup);
 		}
 	}
 }

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Lights.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Lights.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 	public static partial class Prefabs
 	{
 		[MenuItem(Constants.MenuNames.GameObjectMenus.Cameras + "/Menu", priority = CamerasMenuPriority)]
-		private static void CreateMenuCamera()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid CreateMenuCameraAsync()
 		{
-			SafeInstantiate(prefabManager => prefabManager.Cameras.Menu);
+			await SafeInstantiateAsync(prefabManager => prefabManager.Cameras.Menu);
 		}
 	}
 }

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Texts.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.Texts.cs
@@ -1,3 +1,4 @@
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 
 namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
@@ -5,9 +6,10 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 	public static partial class Prefabs
 	{
 		[MenuItem(Constants.MenuNames.GameObjectMenus.Texts + "/Text", priority = UIMenuPriority)]
-		private static void CreateText()
+		// ReSharper disable once Unity.IncorrectMethodSignature
+		private static async UniTaskVoid CreateTextAsync()
 		{
-			SafeInstantiate(prefabManager => prefabManager.Texts.Text);
+			await SafeInstantiateAsync(prefabManager => prefabManager.Texts.Text);
 		}
 
 		[MenuItem(Constants.MenuNames.GameObjectMenus.Texts + "/Text", true)]

--- a/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.cs
+++ b/CommunityProject/Assets/_Game/Scripts/Editor/Menus/GameObjectMenu/Prefabs.cs
@@ -1,5 +1,6 @@
 using System;
 using BoundfoxStudios.CommunityProject.EditorExtensions.ScriptableObjects;
+using Cysharp.Threading.Tasks;
 using UnityEditor;
 using UnityEngine;
 
@@ -18,15 +19,15 @@ namespace BoundfoxStudios.CommunityProject.Editor.Menus.GameObjectMenu
 		private static bool SelectionHasCanvasValidate() =>
 			Selection.activeGameObject && Selection.activeGameObject.GetComponentInParent<Canvas>();
 
-		private static void SafeInstantiate(Func<PrefabManagerSO, GameObject> itemSelector)
+		private static async UniTask SafeInstantiateAsync(Func<PrefabManagerSO, GameObject> itemSelector)
 		{
-			PrefabManager.SafeInvoke(prefabManager =>
+			await PrefabManager.SafeInvokeAsync(prefabManager =>
 			{
 				var item = itemSelector(prefabManager);
 
 				if (!item)
 				{
-					Debug.LogWarning($"{nameof(SafeInstantiate)} invoked, but {nameof(itemSelector)} returned null. " +
+					Debug.LogWarning($"{nameof(SafeInstantiateAsync)} invoked, but {nameof(itemSelector)} returned null. " +
 									 "Did you forget to fill the slot in the inspector?");
 					return;
 				}


### PR DESCRIPTION
**Beschreibung**
Schreibt den Code vom PrefabManager um, um Addressables zu nutzen, was laut Unity seit 1.19.18 (wir nutzen 1.19.19) auch im Editor funktionieren sollte.

## Checkliste
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [ ] Aufgabe verlinkt (falls nicht, PR editieren)
- [ ] Tests geschrieben (nur relevant für Code-Änderungen)
- [ ] Dokumentation aktualisiert (nur relevant für System-Entwicklungen)

## PR Typ
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [ ] Bugfix
- [x] Feature
- [ ] 3D-Modell
- [ ] 2D-Arbeit
- [ ] Sound-Effekte
- [ ] Musik
- [ ] Dokumentation
- [ ] Sonstiges, bitte beschreiben: 
