### PR TITLE
fix: NullRefException in TargetLocator

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetLocatorSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetLocatorSO.cs
@@ -68,7 +68,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.Scriptabl
 		{
 			Debug.Assert(targets > 0, $"{nameof(targets.Size)} must be greater than 0.");
 
-			return targets.Result.PickRandom();
+			return targets.Result.PickRandom(targets)!;
 		}
 
 		private Collider ByClosestTargetTypeNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets)

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Extensions/ArrayExtensions.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Extensions/ArrayExtensions.cs
@@ -4,12 +4,23 @@ namespace BoundfoxStudios.FairyTaleDefender.Extensions
 {
 	public static class ArrayExtensions
 	{
-		public static T PickRandom<T>(this T[]? items)
+		/// <summary>
+		/// Picks a random item in this array.
+		/// </summary>
+		public static T? PickRandom<T>(this T[]? items)
+		{
+			return PickRandom(items, items!.Length);
+		}
+
+		/// <summary>
+		/// Picks a random item in this array within the first element and the last element before given index <paramref name="maxExclusive"/>.
+		/// </summary>
+		public static T? PickRandom<T>(this T[]? items, int maxExclusive)
 		{
 			Debug.Assert(items is not null, "Trying to pick a random from a non-existing array!");
 			Debug.Assert(items!.Length > 0, "Trying to pick a random from an empty array!");
 
-			return items[Random.Range(0, items.Length)];
+			return items[Random.Range(0, maxExclusive)];
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/SettingsController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/SettingsController.cs
@@ -88,7 +88,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem
 
 		private void ApplyGraphicSettings()
 		{
-			QualitySettings.SetQualityLevel((int) Settings.Graphic.GraphicLevel);
+			QualitySettings.SetQualityLevel((int)Settings.Graphic.GraphicLevel);
 		}
 
 		private void ApplyLocalizationSettings()


### PR DESCRIPTION
**Beschreibung**
TargetLocator verwendet nun eine PickRandom Methode die nur aus Elementen im Array bis zu einem bestimmten Index wählt, in diesem Fall die Anzahl an gefilterten Gegnern in Reichweite.
Fixes #262 

## Checkliste
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [x] Aufgabe verlinkt (falls nicht, PR editieren)
- [ ] Tests geschrieben (nur relevant für Code-Änderungen)
- [ ] Dokumentation aktualisiert (nur relevant für System-Entwicklungen)

## PR Typ
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [x] Bugfix
- [ ] Feature
- [ ] 3D-Modell
- [ ] 2D-Arbeit
- [ ] Sound-Effekte
- [ ] Musik
- [ ] Dokumentation
- [ ] Sonstiges, bitte beschreiben: 
