### PR TITLE
refactor: TargetLocator

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Prefabs/Weapons/Catapult/Catapult.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/Weapons/Catapult/Catapult.prefab
@@ -16,7 +16,7 @@ PrefabInstance:
     - target: {fileID: 4417085996939291567, guid: 58040a623dccf48739eb35e77740a26f,
         type: 3}
       propertyPath: m_RootOrder
-      value: -1
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4417085996939291567, guid: 58040a623dccf48739eb35e77740a26f,
         type: 3}
@@ -109,7 +109,8 @@ MonoBehaviour:
   EffectiveWeaponCalculatorSO: {fileID: 11400000, guid: 115fb7de805fc5a4cb4df258470d53f2,
     type: 2}
   <Tower>k__BackingField: {fileID: 0}
-  <TargetType>k__BackingField: 0
+  <TargetType>k__BackingField: {fileID: 11400000, guid: 60b758fae1fe95b44b420de43903e9d1,
+    type: 2}
   <Arm>k__BackingField:
     <ArmPivot>k__BackingField: {fileID: 8953687500045677425}
     <LaunchPoint>k__BackingField: {fileID: 5458708713455915020}

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/ClosestTargetType.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/ClosestTargetType.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 36139b81781c48e79b91ba66d83fc840, type: 3}
+  m_Name: ClosestTargetType
+  m_EditorClassIdentifier: 

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/ClosestTargetType.asset.meta
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/ClosestTargetType.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 60b758fae1fe95b44b420de43903e9d1
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/RandomTargetType.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/RandomTargetType.asset
@@ -1,0 +1,14 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 975252c5e4014f779bffc0a2d3a5306b, type: 3}
+  m_Name: RandomTargetType
+  m_EditorClassIdentifier: 

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/RandomTargetType.asset.meta
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Weapons/Targeting/RandomTargetType.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb9469c0d14e3e84cb027962df1638e0
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/BallisticWeapons/ScriptableObjects/BallisticTargetLocatorSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/BallisticWeapons/ScriptableObjects/BallisticTargetLocatorSO.cs
@@ -7,7 +7,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.BallisticWeapons.Sc
 	[CreateAssetMenu(menuName = Constants.MenuNames.Targeting + "/" + nameof(BallisticTargetLocatorSO))]
 	public class BallisticTargetLocatorSO : TargetLocatorSO<EffectiveBallisticWeaponDefinition>
 	{
-		public override TargetPoint? Locate(Vector3 weaponPosition, Vector3 towerForward, TargetType targetType, EffectiveBallisticWeaponDefinition weaponDefinition)
+		public override TargetPoint? Locate(Vector3 weaponPosition, Vector3 towerForward, TargetTypeSO targetType, EffectiveBallisticWeaponDefinition weaponDefinition)
 		{
 			var targets = LocateAllInRangeNonAlloc(weaponPosition, weaponDefinition.Range.Maximum);
 			var newSize = 0;

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/ClosestTargetTypeSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/ClosestTargetTypeSO.cs
@@ -1,0 +1,44 @@
+using BoundfoxStudios.FairyTaleDefender.Extensions;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.ScriptableObjects
+{
+	/// <summary>
+	/// Target type for selecting closest target.
+	/// </summary>
+	// We don't need more than one instance.
+	// [CreateAssetMenu(fileName = "ClosestTargetType", menuName = Constants.MenuNames.Targeting + "/Closest Target Type")]
+	public class ClosestTargetTypeSO : TargetTypeSO
+	{
+		public override Collider GetTargetNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets)
+		{
+			Debug.Assert(targets > 0, $"{nameof(targets.Size)} must be greater than 0.");
+
+			var closestCollider = targets[0];
+
+			if (targets == 1)
+			{
+				return closestCollider;
+			}
+
+			var smallestDistance = float.PositiveInfinity;
+
+			for (var i = 0; i < targets; i++)
+			{
+				var target = targets[i];
+
+				// Using the squared distance here to avoid using sqrt.
+				var distanceSquared = weaponPosition.DistanceSquaredTo(target.transform.position);
+
+				if (distanceSquared < smallestDistance)
+				{
+					smallestDistance = distanceSquared;
+					closestCollider = target;
+				}
+			}
+
+			return closestCollider;
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/ClosestTargetTypeSO.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/ClosestTargetTypeSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 36139b81781c48e79b91ba66d83fc840
+timeCreated: 1681041094

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/RandomTargetTypeSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/RandomTargetTypeSO.cs
@@ -1,0 +1,23 @@
+using BoundfoxStudios.FairyTaleDefender.Extensions;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.ScriptableObjects
+{
+	/// <summary>
+	/// Target type for selecting a random target.
+	/// </summary>
+	// We don't need more than one instance.
+	// [CreateAssetMenu(fileName = "RandomTargetType", menuName = Constants.MenuNames.Targeting + "/Random Target Type")]
+	public class RandomTargetTypeSO : TargetTypeSO
+	{
+		public override Collider GetTargetNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets)
+		{
+			{
+				Debug.Assert(targets > 0, $"{nameof(targets.Size)} must be greater than 0.");
+
+				return targets.Result.PickRandom(targets)!;
+			}
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/RandomTargetTypeSO.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/RandomTargetTypeSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 975252c5e4014f779bffc0a2d3a5306b
+timeCreated: 1681040971

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetLocatorSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetLocatorSO.cs
@@ -1,5 +1,3 @@
-using System;
-using BoundfoxStudios.FairyTaleDefender.Extensions;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure;
 using UnityEngine;
 
@@ -14,7 +12,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.Scriptabl
 		/// <summary>
 		/// Returns a single target that is reachable by the <paramref name="weaponDefinition"/>.
 		/// </summary>
-		public abstract TargetPoint? Locate(Vector3 weaponPosition, Vector3 towerForward, TargetType targetType,
+		public abstract TargetPoint? Locate(Vector3 weaponPosition, Vector3 towerForward, TargetTypeSO targetType,
 			T weaponDefinition);
 
 		/// <summary>
@@ -47,58 +45,16 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.Scriptabl
 		/// <summary>
 		/// Given an array of possible targets, the method will return a specific one depending on the <paramref name="targetType"/>.
 		/// </summary>
-		protected TargetPoint? ByTargetTypeNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets, TargetType targetType)
+		protected TargetPoint? ByTargetTypeNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets, TargetTypeSO targetType)
 		{
 			if (targets == 0)
 			{
 				return null;
 			}
 
-			var target = targetType switch
-			{
-				TargetType.Closest => ByClosestTargetTypeNonAlloc(weaponPosition, targets),
-				TargetType.Random => ByRandomTargetTypeNonAlloc(targets),
-				_ => throw new ArgumentOutOfRangeException(nameof(targetType), $"{targetType} is not implemented yet.")
-			};
+			var target = targetType.GetTargetNonAlloc(weaponPosition, targets);
 
 			return target.GetComponent<TargetPoint>();
-		}
-
-		private Collider ByRandomTargetTypeNonAlloc(NoAllocArrayResult<Collider> targets)
-		{
-			Debug.Assert(targets > 0, $"{nameof(targets.Size)} must be greater than 0.");
-
-			return targets.Result.PickRandom(targets)!;
-		}
-
-		private Collider ByClosestTargetTypeNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets)
-		{
-			Debug.Assert(targets > 0, $"{nameof(targets.Size)} must be greater than 0.");
-
-			var closestCollider = targets[0];
-
-			if (targets == 1)
-			{
-				return closestCollider;
-			}
-
-			var smallestDistance = float.PositiveInfinity;
-
-			for (var i = 0; i < targets; i++)
-			{
-				var target = targets[i];
-
-				// Using the squared distance here to avoid using sqrt.
-				var distanceSquared = weaponPosition.DistanceSquaredTo(target.transform.position);
-
-				if (distanceSquared < smallestDistance)
-				{
-					smallestDistance = distanceSquared;
-					closestCollider = target;
-				}
-			}
-
-			return closestCollider;
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetTypeSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetTypeSO.cs
@@ -1,0 +1,10 @@
+using BoundfoxStudios.FairyTaleDefender.Infrastructure;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting.ScriptableObjects
+{
+	public abstract class TargetTypeSO : ScriptableObject
+	{
+		public abstract Collider GetTargetNonAlloc(Vector3 weaponPosition, NoAllocArrayResult<Collider> targets);
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetTypeSO.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/ScriptableObjects/TargetTypeSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ab6f6672beed499895e9f9490ab5557e
+timeCreated: 1681040862

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/TargetType.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/TargetType.cs
@@ -1,8 +1,0 @@
-namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons.Targeting
-{
-	public enum TargetType
-	{
-		Closest = 0,
-		Random = 1,
-	}
-}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/TargetType.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Targeting/TargetType.cs.meta
@@ -1,3 +1,0 @@
-fileFormatVersion: 2
-guid: 96c9c3b684fd4907826b3c899ec15ae8
-timeCreated: 1674053961

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Weapon.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Weapons/Weapon.cs
@@ -31,7 +31,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Weapons
 		public Tower Tower { get; private set; } = default!;
 
 		[field: SerializeField]
-		public TargetType TargetType { get; private set; }
+		public TargetTypeSO TargetType { get; private set; } = default!;
 
 		private TEffectiveWeaponDefinition EffectiveWeaponDefinition =>
 			_effectiveWeaponDefinition ??=


### PR DESCRIPTION
**Beschreibung**
TargetType ist nun als ScriptableObject implementiert statt als Enum. Damit kann der Code zum wählen des Ziels aus nutzenden Klassen wie dem TargetLocator gezogen werden.
Resolves #200 

## Checkliste
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [x] Aufgabe verlinkt (falls nicht, PR editieren)
- [ ] Tests geschrieben (nur relevant für Code-Änderungen)
- [ ] Dokumentation aktualisiert (nur relevant für System-Entwicklungen)

## PR Typ
<!-- Bitte lösche diese Liste nicht. Du kannst sie nach dem Stellen des PRs abhaken. -->

- [ ] Bugfix
- [ ] Feature
- [ ] 3D-Modell
- [ ] 2D-Arbeit
- [ ] Sound-Effekte
- [ ] Musik
- [ ] Dokumentation
- [ ] Sonstiges, bitte beschreiben: 
