### PR TITLE
replace BuildTargetGroup with StandaloneBuildTarget

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scripts/Editor/Build/EnableSteamIntegration.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Editor/Build/EnableSteamIntegration.cs
@@ -25,12 +25,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Editor.Build
 				return;
 			}
 
-			PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup,
+			PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.Standalone,
 				out var defines);
 
 			var uniqueDefines = new HashSet<string>(defines) { Constants.CompilerDirectives.EnableSteam };
 
-			PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup,
+			PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.Standalone,
 				uniqueDefines.ToArray());
 		}
 	}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Editor/Menus/SteamIntegrationButton.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Editor/Menus/SteamIntegrationButton.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Reflection;
 using Cysharp.Threading.Tasks;
 using UnityEditor;
-using UnityEditor.Experimental;
+using UnityEditor.Build;
 using UnityEngine;
 using UnityEngine.AddressableAssets;
 using UnityEngine.UIElements;
@@ -74,7 +74,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Editor.Menus
 
 		private static bool IsSteamIntegrationEnabled(out HashSet<string> uniqueDefines)
 		{
-			PlayerSettings.GetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup,
+			PlayerSettings.GetScriptingDefineSymbols(NamedBuildTarget.Standalone,
 				out var defines);
 
 			uniqueDefines = new(defines);
@@ -89,14 +89,13 @@ namespace BoundfoxStudios.FairyTaleDefender.Editor.Menus
 			if (isSteamIntegrationEnabled)
 			{
 				uniqueDefines.Remove(Constants.CompilerDirectives.EnableSteam);
-				PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup,
-					uniqueDefines.ToArray());
-
-				return;
+			}
+			else
+			{
+				uniqueDefines.Add(Constants.CompilerDirectives.EnableSteam);
 			}
 
-			uniqueDefines.Add(Constants.CompilerDirectives.EnableSteam);
-			PlayerSettings.SetScriptingDefineSymbolsForGroup(EditorUserBuildSettings.selectedBuildTargetGroup,
+			PlayerSettings.SetScriptingDefineSymbols(NamedBuildTarget.Standalone,
 				uniqueDefines.ToArray());
 		}
 


### PR DESCRIPTION
**Beschreibung**
Die als veraltet markierten Methoden Set/- GetScriptingDefineSymbolsForGroup mit BuildTargetGroup als Parameter wurden durch Set/- GetScriptingDefineSymbols mit NamedBuildTarget.Standalone als Argument ersetzt.
Etwas hacky, aber da Steam nur auf Standalone ist und das Projekt nur Standalone als Target hat, könnte es ok sein :)

closes #278 
