### PR TITLE
feat: no selection after build

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Prefabs/UI/Canvas.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/UI/Canvas.prefab
@@ -57,6 +57,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -99,4 +100,4 @@ MonoBehaviour:
   m_BlockingObjects: 0
   m_BlockingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 32

--- a/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
@@ -1101,6 +1101,7 @@ MonoBehaviour:
   <TowerLayerMask>k__BackingField:
     serializedVersion: 2
     m_Bits: 512
+  <GraphicRaycaster>k__BackingField: {fileID: 1691620299}
 --- !u!4 &1593510016
 Transform:
   m_ObjectHideFlags: 0
@@ -1488,6 +1489,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1691620297}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1691620299 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7329999705680356851, guid: 42707aee6922e4159909253356ec706a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1691620297}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1801829371
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
     type: 3}
   <BlueprintPrefab>k__BackingField: {fileID: 9013187241264066330, guid: e9c51145ac61348f0b17f648102a5d9b,
     type: 3}
+  <Price>k__BackingField: 10

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
@@ -1,7 +1,9 @@
+using System;
 using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Extensions;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects.CallbackProcessors;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects
@@ -134,9 +136,16 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableGameplayInput()
 		{
 			GameInput.BuildSystem.Disable();
-			GameInput.Gameplay.Enable();
-			GameInput.UI.Enable();
-			GameInput.Camera.Enable();
+
+			// TODO: Bring this back to sync code if that is really an issue with the InputSystem.
+			// There seems to be an issue in the InputSystem.
+			// If you enable an action during handling another action it seems to trigger the activated actions as well.
+			DoDelayedAsync(() =>
+			{
+				GameInput.Gameplay.Enable();
+				GameInput.UI.Enable();
+				GameInput.Camera.Enable();
+			}).Forget();
 		}
 
 		private void DisableTooltipInput()
@@ -147,6 +156,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableTooltipInput()
 		{
 			GameInput.Tooltips.Enable();
+		}
+
+		private async UniTaskVoid DoDelayedAsync(Action callback)
+		{
+			await UniTask.Delay(250);
+			callback();
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/SelectionController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/SelectionController.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Entities.Weapons;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.RuntimeAnchors.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 {
@@ -27,7 +30,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 		[field: SerializeField]
 		private LayerMask TowerLayerMask { get; set; }
 
+		[field: SerializeField]
+		private GraphicRaycaster GraphicRaycaster { get; set; } = default!;
+
 		private Transform? _currentSelection;
+
+		private List<RaycastResult> _uiOverGameObjectResultCache = new(1);
 
 		private void OnEnable()
 		{
@@ -39,9 +47,22 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 			InputReader.GameplayActions.Click -= GameplayActionsOnClick;
 		}
 
+		private bool IsPointerOverGameObject(Vector2 position)
+		{
+			var pointerEventData = new PointerEventData(EventSystem.current)
+			{
+				position = position
+			};
+
+			_uiOverGameObjectResultCache.Clear();
+			GraphicRaycaster.Raycast(pointerEventData, _uiOverGameObjectResultCache);
+
+			return _uiOverGameObjectResultCache.Count > 0;
+		}
+
 		private void GameplayActionsOnClick(Vector2 position)
 		{
-			if (!CameraRuntimeAnchor.Item)
+			if (!CameraRuntimeAnchor.Item || IsPointerOverGameObject(position))
 			{
 				return;
 			}
@@ -66,7 +87,8 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 			}
 
 			_currentSelection = hitInfo.transform;
-			var canCalculateWeaponDefinition = _currentSelection.GetComponentInChildren<ICanCalculateEffectiveWeaponDefinition>();
+			var canCalculateWeaponDefinition =
+				_currentSelection.GetComponentInChildren<ICanCalculateEffectiveWeaponDefinition>();
 			WeaponSelectedEventChannel.Raise(new()
 			{
 				Transform = _currentSelection,


### PR DESCRIPTION
**Beschreibung**

Aus dem Discord:
> Sobald wir den Baus-Modus verlassen, aktivieren wir wieder die Gameplay-Actions. Und die Triggern den Click sofort, sogar 2x. Erscheint mir nicht richtig. 
Hab ein Workaround, einfach ein Delay zwischen dem Beenden vom Baumodus und dem aktivieren der Actions. 
Cool find ich das aktuell nicht. Bug bei Unity hab ich eingereicht

Zudem wird in diesem PR auch der `SelectionController` angepasst, sodass dieser nicht mehr versucht einen Raycast zu machen, sobald man auf ein UI-Element klickt. Das wird spätestens passieren, wenn wir einem Turm eine UI geben, wenn er selektiert wurde.

fixes #325 