### PR TITLE
Turm platzieren bei Maus loslassen/ Alternative zu PR #342

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Prefabs/UI/Canvas.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/UI/Canvas.prefab
@@ -57,6 +57,7 @@ Canvas:
   m_OverridePixelPerfect: 0
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
+  m_UpdateRectTransformForStandalone: 0
   m_SortingLayerID: 0
   m_SortingOrder: 0
   m_TargetDisplay: 0
@@ -99,4 +100,4 @@ MonoBehaviour:
   m_BlockingObjects: 0
   m_BlockingMask:
     serializedVersion: 2
-    m_Bits: 4294967295
+    m_Bits: 32

--- a/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
@@ -1101,6 +1101,7 @@ MonoBehaviour:
   <TowerLayerMask>k__BackingField:
     serializedVersion: 2
     m_Bits: 512
+  <GraphicRaycaster>k__BackingField: {fileID: 1691620299}
 --- !u!4 &1593510016
 Transform:
   m_ObjectHideFlags: 0
@@ -1488,6 +1489,18 @@ RectTransform:
     type: 3}
   m_PrefabInstance: {fileID: 1691620297}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1691620299 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 7329999705680356851, guid: 42707aee6922e4159909253356ec706a,
+    type: 3}
+  m_PrefabInstance: {fileID: 1691620297}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1001 &1801829371
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
@@ -16,3 +16,4 @@ MonoBehaviour:
     type: 3}
   <BlueprintPrefab>k__BackingField: {fileID: 9013187241264066330, guid: e9c51145ac61348f0b17f648102a5d9b,
     type: 3}
+  <Price>k__BackingField: 10

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/CallbackProcessors/BuildSystemActionsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/CallbackProcessors/BuildSystemActionsSO.cs
@@ -13,6 +13,8 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		public event Action Rotate = delegate { };
 		public event Action Cancel = delegate { };
 
+		private Vector2 _lastPosition;
+
 		public void OnBuildPosition(InputAction.CallbackContext context)
 		{
 			if (!context.performed)
@@ -20,17 +22,18 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 				return;
 			}
 
-			Position(context.ReadValue<Vector2>());
+			_lastPosition = context.ReadValue<Vector2>();
+			Position(_lastPosition);
 		}
 
 		public void OnBuild(InputAction.CallbackContext context)
 		{
-			if (!context.performed)
+			if (!context.canceled)
 			{
 				return;
 			}
 
-			Build(context.ReadValue<Vector2>());
+			Build(_lastPosition);
 		}
 
 		public void OnBuildRotate(InputAction.CallbackContext context)

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/CallbackProcessors/GameplayActionsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/CallbackProcessors/GameplayActionsSO.cs
@@ -9,14 +9,17 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 	{
 		public event InputReaderSO.ScreenPositionHandler Click = delegate { };
 
+		private Vector2 _lastPosition;
+
 		public void OnClick(InputAction.CallbackContext context)
 		{
-			if (!context.performed)
+			if (!context.canceled)
 			{
+				_lastPosition = context.ReadValue<Vector2>();
 				return;
 			}
 
-			Click(context.ReadValue<Vector2>());
+			Click(_lastPosition);
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
@@ -1,7 +1,9 @@
+using System;
 using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Extensions;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects.CallbackProcessors;
+using Cysharp.Threading.Tasks;
 using UnityEngine;
 
 namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects
@@ -134,9 +136,16 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableGameplayInput()
 		{
 			GameInput.BuildSystem.Disable();
-			GameInput.Gameplay.Enable();
-			GameInput.UI.Enable();
-			GameInput.Camera.Enable();
+
+			// TODO: Bring this back to sync code if that is really an issue with the InputSystem.
+			// There seems to be an issue in the InputSystem.
+			// If you enable an action during handling another action it seems to trigger the activated actions as well.
+			DoDelayedAsync(() =>
+			{
+				GameInput.Gameplay.Enable();
+				GameInput.UI.Enable();
+				GameInput.Camera.Enable();
+			}).Forget();
 		}
 
 		private void DisableTooltipInput()
@@ -147,6 +156,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableTooltipInput()
 		{
 			GameInput.Tooltips.Enable();
+		}
+
+		private async UniTaskVoid DoDelayedAsync(Action callback)
+		{
+			await UniTask.Delay(250);
+			callback();
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
@@ -87,6 +87,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 
 		private void ExitBuildMode()
 		{
+			GameInput.BuildSystem.Disable();
 			EnableGameplayInput();
 		}
 
@@ -104,7 +105,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 
 		private void GameplayStart()
 		{
-			EnableGameplayInput();
+			EnableGameplayInputDelayedAsync();
 		}
 
 		private void DisableAllInput()
@@ -133,19 +134,22 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 			GameInput.Camera.Enable();
 		}
 
-		private void EnableGameplayInput()
+		private void EnableGameplayInputDelayedAsync()
 		{
 			GameInput.BuildSystem.Disable();
 
 			// TODO: Bring this back to sync code if that is really an issue with the InputSystem.
 			// There seems to be an issue in the InputSystem.
 			// If you enable an action during handling another action it seems to trigger the activated actions as well.
-			DoDelayedAsync(() =>
-			{
-				GameInput.Gameplay.Enable();
-				GameInput.UI.Enable();
-				GameInput.Camera.Enable();
-			}).Forget();
+			// Cancel Events may be an exception here, they don't seem to be passed through.
+			DoDelayedAsync(EnableGameplayInput).Forget();
+		}
+
+		private void EnableGameplayInput()
+		{
+			GameInput.Gameplay.Enable();
+			GameInput.UI.Enable();
+			GameInput.Camera.Enable();
 		}
 
 		private void DisableTooltipInput()

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/ScriptableObjects/InputReaderSO.cs
@@ -137,12 +137,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableGameplayInputDelayedAsync()
 		{
 			GameInput.BuildSystem.Disable();
-
-			// TODO: Bring this back to sync code if that is really an issue with the InputSystem.
-			// There seems to be an issue in the InputSystem.
-			// If you enable an action during handling another action it seems to trigger the activated actions as well.
-			// Cancel Events may be an exception here, they don't seem to be passed through.
-			DoDelayedAsync(EnableGameplayInput).Forget();
+			EnableGameplayInput();
 		}
 
 		private void EnableGameplayInput()
@@ -160,12 +155,6 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObject
 		private void EnableTooltipInput()
 		{
 			GameInput.Tooltips.Enable();
-		}
-
-		private async UniTaskVoid DoDelayedAsync(Action callback)
-		{
-			await UniTask.Delay(250);
-			callback();
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/SelectionController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/InputSystem/SelectionController.cs
@@ -1,9 +1,12 @@
+using System.Collections.Generic;
 using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Entities.Weapons;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.RuntimeAnchors.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Systems.InputSystem.ScriptableObjects;
 using UnityEngine;
+using UnityEngine.EventSystems;
+using UnityEngine.UI;
 
 namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 {
@@ -27,7 +30,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 		[field: SerializeField]
 		private LayerMask TowerLayerMask { get; set; }
 
+		[field: SerializeField]
+		private GraphicRaycaster GraphicRaycaster { get; set; } = default!;
+
 		private Transform? _currentSelection;
+
+		private List<RaycastResult> _uiOverGameObjectResultCache = new(1);
 
 		private void OnEnable()
 		{
@@ -39,9 +47,22 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 			InputReader.GameplayActions.Click -= GameplayActionsOnClick;
 		}
 
+		private bool IsPointerOverGameObject(Vector2 position)
+		{
+			var pointerEventData = new PointerEventData(EventSystem.current)
+			{
+				position = position
+			};
+
+			_uiOverGameObjectResultCache.Clear();
+			GraphicRaycaster.Raycast(pointerEventData, _uiOverGameObjectResultCache);
+
+			return _uiOverGameObjectResultCache.Count > 0;
+		}
+
 		private void GameplayActionsOnClick(Vector2 position)
 		{
-			if (!CameraRuntimeAnchor.Item)
+			if (!CameraRuntimeAnchor.Item || IsPointerOverGameObject(position))
 			{
 				return;
 			}
@@ -66,7 +87,8 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.InputSystem
 			}
 
 			_currentSelection = hitInfo.transform;
-			var canCalculateWeaponDefinition = _currentSelection.GetComponentInChildren<ICanCalculateEffectiveWeaponDefinition>();
+			var canCalculateWeaponDefinition =
+				_currentSelection.GetComponentInChildren<ICanCalculateEffectiveWeaponDefinition>();
 			WeaponSelectedEventChannel.Raise(new()
 			{
 				Transform = _currentSelection,


### PR DESCRIPTION
**Beschreibung**
Andere Herangehensweise zu PR #342 um nicht mehr automatisch Tower zu selektieren nach platzieren (siehe #325).
Clicks werden jetzt allgemein erst mit MouseUp/Cancel ausgelöst, was natürlich erstmal das grundsätzliche Verhalten ändert...
Das macht es natürlich auch wieder zu einem Workaround.
Scheinbar werden die Cancel Events jedoch nicht weitergeleitet, falls die Actions gewechselt werden. Da hatte ich wohl doch noch etwas anderes falsch gemacht...
Habe jetzt die Delayed Methode noch drin gelassen, das Problem würde ja sonst noch weiterhin bestehen, falls in perfomed gewechselt wird.
So müsste man halt die MousePosition schon vor canceln cachen, da die Position sonst resetet wird. Dadurch tritt mit der aktuellen Lösung auch Wiederholung in den verschiedenen Actions auf, die meisten brauchen irgendwie doch eine Position. Sollte man die dann zentral irgendwo cachen?

May close #325 :)
Kannst dir ja aussuchen dann, welche Variante du besser findest :)