### PR TITLE
Nur Turmreichweite von aktuellem Turm bei Platzieren anzeigen

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
@@ -666,6 +666,18 @@ MonoBehaviour:
     type: 2}
   <WeaponDeselectedEventChannel>k__BackingField: {fileID: 11400000, guid: e80022fa2bdfeb845a9a735d96f15878,
     type: 2}
+--- !u!114 &449263549 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8974376439884702617, guid: db6958c5b4bfb0d4c8fd62b3cb32aaf9,
+    type: 3}
+  m_PrefabInstance: {fileID: 449263545}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 449263546}
+  m_Enabled: 0
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0777d029ed3dffa4692f417d4aba19ca, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &556209361
 GameObject:
   m_ObjectHideFlags: 0
@@ -1088,8 +1100,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <Default>k__BackingField: {fileID: 11400000, guid: 60b3d0ae46fe744798c866febf25ba33,
     type: 2}
-  <Build>k__BackingField: {fileID: 11400000, guid: d90a6341fea1641b1baaba74e51558aa,
-    type: 2}
   <EnterBuildModeEventChannel>k__BackingField: {fileID: 11400000, guid: ba08fca58cb80430883e7a626ae9d678,
     type: 2}
   <ExitBuildModeEventChannel>k__BackingField: {fileID: 11400000, guid: cb5eeb0921c8347829f129c42bdeb130,
@@ -1119,6 +1129,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1593510016}
   - component: {fileID: 1593510015}
+  - component: {fileID: 1593510017}
   m_Layer: 0
   m_Name: SelectionController
   m_TagString: Untagged
@@ -1166,6 +1177,35 @@ Transform:
   - {fileID: 449263547}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1593510017
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1593510014}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a5c40375f67547fbac42396a48b5ebad, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <EventChannel>k__BackingField: {fileID: 11400000, guid: ba08fca58cb80430883e7a626ae9d678,
+    type: 2}
+  <EventResponse>k__BackingField:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 449263549}
+        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
+        m_MethodName: set_enabled
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &1620236863
 GameObject:
   m_ObjectHideFlags: 0

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/CharacterStateMachine.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/CharacterStateMachine.cs
@@ -38,7 +38,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Characters.StateMachine
 
 			if (!_states.TryGetValue(typeof(T), out var state))
 			{
-				throw new ($"Trying to enter state {typeof(T).Name}, but it was no added.");
+				throw new($"Trying to enter state {typeof(T).Name}, but it was no added.");
 			}
 
 			_currentState = state;

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/States/HobblingState.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/States/HobblingState.cs
@@ -13,6 +13,6 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Characters.StateMachine.Sta
 			Character.GetComponent<SplineWalker>().MovementSpeed = Character.Definition.MovementSpeed * Character.Definition.HobbleSpeedPercentage;
 		}
 
-		public override void Exit() {}
+		public override void Exit() { }
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/States/IdleState.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Characters/StateMachine/States/IdleState.cs
@@ -5,8 +5,8 @@ namespace BoundfoxStudios.FairyTaleDefender.Entities.Characters.StateMachine.Sta
 	public class IdleState<TDefinition> : BaseState<TDefinition>
 		where TDefinition : CharacterSO
 	{
-		public override void Enter() {}
+		public override void Enter() { }
 
-		public override void Exit() {}
+		public override void Exit() { }
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 06d8e56d258f48278d03bbc5ff1757ff
+timeCreated: 1696413973

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs
@@ -1,10 +1,10 @@
-﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using UnityEngine;
 
 namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
 {
-	[AddComponentMenu(Constants.MenuNames.Events + "/Buildable Event Channel Listener")]
+	[AddComponentMenu(Constants.MenuNames.Events + "/" + nameof(BuildableEventChannelListener))]
 	public class BuildableEventChannelListener : EventChannelListener<BuildableEventChannelSO, BuildableEventChannelSO.EventArgs>
 	{
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs
@@ -1,0 +1,12 @@
+﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
+{
+	[AddComponentMenu(Constants.MenuNames.Events + "/Buildable Event Channel Listener")]
+	public class BuildableEventChannelListener : EventChannelListener<BuildableEventChannelSO, BuildableEventChannelSO.EventArgs>
+	{
+
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/BuildableEventChannelListener.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a5c40375f67547fbac42396a48b5ebad
+timeCreated: 1696415094

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs
@@ -1,10 +1,10 @@
-﻿using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using UnityEngine;
 using UnityEngine.Events;
 
 namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
 {
-	public class EventChannelListener<TEventChannelSO, T> : MonoBehaviour where TEventChannelSO : EventChannelSO<T>
+	public abstract class EventChannelListener<TEventChannelSO, T> : MonoBehaviour where TEventChannelSO : EventChannelSO<T>
 	{
 		[field: SerializeField] public TEventChannelSO EventChannel { get; private set; } = default!;
 		[field: SerializeField] public UnityEvent<T> EventResponse { get; private set; } = default!;

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs
@@ -1,0 +1,27 @@
+﻿using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
+{
+	public class EventChannelListener<TEventChannelSO, T> : MonoBehaviour where TEventChannelSO : EventChannelSO<T>
+	{
+		[field: SerializeField] public TEventChannelSO EventChannel { get; private set; } = default!;
+		[field: SerializeField] public UnityEvent<T> EventResponse { get; private set; } = default!;
+
+		private void OnEnable()
+		{
+			EventChannel.Raised += Respond;
+		}
+
+		private void OnDisable()
+		{
+			EventChannel.Raised -= Respond;
+		}
+
+		private void Respond(T args)
+		{
+			EventResponse.Invoke(args);
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/EventChannelListener.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: ebaa65b1297943cc8fe80be665171068
+timeCreated: 1696415130

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs
@@ -1,11 +1,11 @@
-﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
 using UnityEngine;
 using UnityEngine.Events;
 
 namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
 {
-	[AddComponentMenu(Constants.MenuNames.Events + "/Void Event Channel Listener")]
+	[AddComponentMenu(Constants.MenuNames.Events + "/" + nameof(VoidEventChannelListener))]
 	public class VoidEventChannelListener : MonoBehaviour
 	{
 		[field: SerializeField] public VoidEventChannelSO EventChannel { get; private set; } = default!;

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs
@@ -1,0 +1,29 @@
+﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
+using UnityEngine;
+using UnityEngine.Events;
+
+namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.Listener
+{
+	[AddComponentMenu(Constants.MenuNames.Events + "/Void Event Channel Listener")]
+	public class VoidEventChannelListener : MonoBehaviour
+	{
+		[field: SerializeField] public VoidEventChannelSO EventChannel { get; private set; } = default!;
+		[field: SerializeField] public UnityEvent EventResponse { get; private set; } = default!;
+
+		private void OnEnable()
+		{
+			EventChannel.Raised += Respond;
+		}
+
+		private void OnDisable()
+		{
+			EventChannel.Raised -= Respond;
+		}
+
+		private void Respond()
+		{
+			EventResponse.Invoke();
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/Listener/VoidEventChannelListener.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 35a6517be99b4219a6a7d1f1d23f05b8
+timeCreated: 1696413988


### PR DESCRIPTION
Event Channel Listener als Monobehaviour hinzugefügt und diese genutzt um Waffenreichweite auszublenden sobald ein neuer Turm zum Platzieren gewählt wurde.

closes #348 