### PR TITLE
feat: align gem and heart

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Prefabs/UI/Texts/CoinDisplay.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/UI/Texts/CoinDisplay.prefab
@@ -9,11 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 4988610118661093225}
-  - component: {fileID: 1872163660226790766}
-  - component: {fileID: 8962530189050809457}
   - component: {fileID: 3711070096682446836}
   m_Layer: 5
-  m_Name: Image
+  m_Name: ImageContainer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -30,7 +28,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 3967071707401315080}
   m_Father: {fileID: 7718359279462185691}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -38,21 +37,78 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 40}
   m_Pivot: {x: 0, y: 0.5}
---- !u!222 &1872163660226790766
-CanvasRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1395646658729627313}
-  m_CullTransparentMesh: 1
---- !u!114 &8962530189050809457
+--- !u!114 &3711070096682446836
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1395646658729627313}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 40
+  m_MinHeight: -1
+  m_PreferredWidth: -1
+  m_PreferredHeight: -1
+  m_FlexibleWidth: -1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
+--- !u!1 &4490233560023742569
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3967071707401315080}
+  - component: {fileID: 127928685419410565}
+  - component: {fileID: 3467838504481327364}
+  m_Layer: 5
+  m_Name: Image
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3967071707401315080
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4490233560023742569}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 4988610118661093225}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0.0000038146973, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &127928685419410565
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4490233560023742569}
+  m_CullTransparentMesh: 1
+--- !u!114 &3467838504481327364
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4490233560023742569}
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
@@ -76,26 +132,6 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
---- !u!114 &3711070096682446836
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1395646658729627313}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreLayout: 0
-  m_MinWidth: -1
-  m_MinHeight: -1
-  m_PreferredWidth: 24
-  m_PreferredHeight: -1
-  m_FlexibleWidth: -1
-  m_FlexibleHeight: -1
-  m_LayoutPriority: 1
 --- !u!1 &8177922407582297086
 GameObject:
   m_ObjectHideFlags: 0
@@ -192,7 +228,7 @@ MonoBehaviour:
     m_Top: 8
     m_Bottom: 8
   m_ChildAlignment: 4
-  m_Spacing: 8
+  m_Spacing: 4
   m_ChildForceExpandWidth: 0
   m_ChildForceExpandHeight: 1
   m_ChildControlWidth: 1
@@ -326,7 +362,7 @@ PrefabInstance:
     - target: {fileID: 5939346216126308751, guid: f044ccc8a6e784128a33f514b5385ffe,
         type: 3}
       propertyPath: m_fontSize
-      value: 25
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 5939346216126308751, guid: f044ccc8a6e784128a33f514b5385ffe,
         type: 3}
@@ -351,7 +387,7 @@ PrefabInstance:
     - target: {fileID: 5939346216126308751, guid: f044ccc8a6e784128a33f514b5385ffe,
         type: 3}
       propertyPath: m_fontSizeBase
-      value: 25
+      value: 23
       objectReference: {fileID: 0}
     - target: {fileID: 5939346216126308751, guid: f044ccc8a6e784128a33f514b5385ffe,
         type: 3}

--- a/FairyTaleDefender/Assets/_Game/Prefabs/UI/Texts/LifeDisplay.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/UI/Texts/LifeDisplay.prefab
@@ -8,6 +8,12 @@ PrefabInstance:
     serializedVersion: 3
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 3467838504481327364, guid: f1ef1f1fad8194628aee58fd19ad3ecd,
+        type: 3}
+      propertyPath: m_Sprite
+      value: 
+      objectReference: {fileID: 21300000, guid: b792666d57f394425b42ef5acf6a589c,
+        type: 3}
     - target: {fileID: 3711070096682446836, guid: f1ef1f1fad8194628aee58fd19ad3ecd,
         type: 3}
       propertyPath: m_PreferredWidth
@@ -166,7 +172,7 @@ PrefabInstance:
     - target: {fileID: 8177922407582297086, guid: f1ef1f1fad8194628aee58fd19ad3ecd,
         type: 3}
       propertyPath: m_Name
-      value: LiveDisplay
+      value: LifeDisplay
       objectReference: {fileID: 0}
     - target: {fileID: 8962530189050809457, guid: f1ef1f1fad8194628aee58fd19ad3ecd,
         type: 3}


### PR DESCRIPTION
fixes #396

**Beschreibung**

Korrekte Ausrichtung von Gem und Herz:

![image](https://github.com/BoundfoxStudios/fairy-tale-defender/assets/740791/fe65e40d-a620-48e7-ad81-edad555c345e)
