### PR TITLE
Cinemachine Confiner hinzugefügt und an die WorldBounds angepasst.

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scenes/Levels/LittleRedRidingHood/Level_1.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Levels/LittleRedRidingHood/Level_1.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.18028326, g: 0.22571333, b: 0.30692202, a: 1}
+  m_IndirectSpecularColor: {r: 0.18028378, g: 0.22571412, b: 0.30692285, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -3533,6 +3533,12 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 264923929}
   m_PrefabAsset: {fileID: 0}
+--- !u!65 &265217439 stripped
+BoxCollider:
+  m_CorrespondingSourceObject: {fileID: 184857218, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+    type: 3}
+  m_PrefabInstance: {fileID: 1962033812}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &267120023
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -6402,6 +6408,26 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 497334774}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &502549413 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 8810243973549469639, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+    type: 3}
+  m_PrefabInstance: {fileID: 1962033812}
+  m_PrefabAsset: {fileID: 0}
+--- !u!114 &502549418
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 502549413}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d75924d76b05344aa410607bc57db98, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  BoundingVolume: {fileID: 265217439}
+  SlowingDistance: 0
 --- !u!1001 &507607337
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -39933,19 +39959,19 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 184857218, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
       propertyPath: m_Size.x
-      value: 21.302475
+      value: 8.258768
       objectReference: {fileID: 0}
     - target: {fileID: 184857218, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
       propertyPath: m_Size.z
-      value: 21.406015
+      value: 19.23112
       objectReference: {fileID: 0}
     - target: {fileID: 184857218, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
       propertyPath: m_Center.x
-      value: 2.9030678
+      value: 2.7264464
       objectReference: {fileID: 0}
     - target: {fileID: 184857218, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
       propertyPath: m_Center.z
-      value: 5.6765256
+      value: 4.201268
       objectReference: {fileID: 0}
     - target: {fileID: 1633943522015870932, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
@@ -40030,22 +40056,22 @@ PrefabInstance:
     - target: {fileID: 3757737759340830362, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 0.8535534
+      value: 0.8172248
       objectReference: {fileID: 0}
     - target: {fileID: 3757737759340830362, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalRotation.x
-      value: 0.35355338
+      value: 0.43092582
       objectReference: {fileID: 0}
     - target: {fileID: 3757737759340830362, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.35355338
+      value: -0.33850566
       objectReference: {fileID: 0}
     - target: {fileID: 3757737759340830362, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.1464466
+      value: 0.17849532
       objectReference: {fileID: 0}
     - target: {fileID: 4482851638519967022, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
@@ -40055,12 +40081,32 @@ PrefabInstance:
     - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 7.1500006
+      value: 5.0584826
       objectReference: {fileID: 0}
     - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -4.6900005
+      value: -2.598483
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 0.8172248
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0.43092582
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0.33850566
+      objectReference: {fileID: 0}
+    - target: {fileID: 5954598677870537128, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0.17849532
       objectReference: {fileID: 0}
     - target: {fileID: 8810243973549469639, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
         type: 3}
@@ -40070,9 +40116,14 @@ PrefabInstance:
     m_RemovedComponents:
     - {fileID: 7545943087246542470, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
     - {fileID: 7646601865440920395, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
+    - {fileID: 6629963924695851990, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
-    m_AddedComponents: []
+    m_AddedComponents:
+    - targetCorrespondingSourceObject: {fileID: 8810243973549469639, guid: 35d7ecd3de7fe484793c6fd2f5bff083,
+        type: 3}
+      insertIndex: -1
+      addedObject: {fileID: 502549418}
   m_SourcePrefab: {fileID: 100100000, guid: 35d7ecd3de7fe484793c6fd2f5bff083, type: 3}
 --- !u!1001 &1964653295
 PrefabInstance:

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/CameraSystem/CameraController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/CameraSystem/CameraController.cs
@@ -28,7 +28,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.CameraSystem
 		{
 			_followTarget = VirtualCamera.Follow;
 
-			AdjustWorldBounds();
+			//AdjustWorldBounds();
 		}
 
 		private void AdjustWorldBounds()


### PR DESCRIPTION
CameraRig_Level ->VirtualCamera -> +Cinematic Confiner3D hinzugefügt. WordBounds angepasst.
Im CameraController die Verwendung der "AdjustWorldBounds" Methode auskommentiert.

**Beschreibung**
Hallo das ist mein erster PR. Ich hoffe ich habe das Problem so gelöst ,wie gewünscht.  Zuerst habe ich die Methode AdjustWorldBounds im CameraController auskommentiert um zu sehen dass die Kamera keine Bounds hat. Danach habe ich einen Cinemachine Confier zur Cinemachine in Level1 hinzugefügt der sich an den WorldBounds orientiert. Anslchließend noch die WorldBounds von der Größe angepasst damit die Kamera besser passt. 

Ich wollte damit folgendes Problem lösen:
https://github.com/BoundfoxStudios/fairy-tale-defender/issues/214