### PR TITLE
Bug: Einstellungen werden nicht korrekt gespeichert.

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -45,7 +45,6 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 				return false;
 
 			_gameSettings = await _jsonFileManager.ReadAsync<GameSettings>(_jsonFileName);
-			return true;
 		}
 
 		private void SetStartConfig()

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -37,7 +37,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			await _jsonFileManager.WriteAsync(_jsonFileName, _gameSettings.EnsureOrThrow());
 		}
 
-		public async UniTask<bool> LoadAsync()
+		public async UniTask LoadAsync()
 		{
 			var fileExists = await _jsonFileManager.ExistsAsync(_jsonFileName);
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -5,6 +5,7 @@ using BoundfoxStudios.FairyTaleDefender.Infrastructure.FileManagement;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
 using UnityEngine.Localization;
+using UnityEngine.Localization.Settings;
 
 namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObjects
 {
@@ -35,14 +36,38 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			await _jsonFileManager.WriteAsync(_jsonFileName, _gameSettings.EnsureOrThrow());
 		}
 
-		public async UniTask LoadAsync()
+		public async UniTask<bool> LoadAsync()
 		{
 			var fileExists = await _jsonFileManager.ExistsAsync(_jsonFileName);
 
 			if (!fileExists)
-				return;
+				return false;
 
 			_gameSettings = await _jsonFileManager.ReadAsync<GameSettings>(_jsonFileName);
+			return true;
+		}
+
+		public void SetStartConfig()
+		{
+			SetStartLocale();
+			SetStartResolution();
+		}
+
+		private void SetStartLocale()
+		{
+			if (Localization.Locale == default)
+			{
+				Localization.Locale = LocalizationSettings.SelectedLocale.Identifier;
+			}
+		}
+
+		private void SetStartResolution()
+		{
+			if (Graphic.ScreenWidth == 0 || Graphic.ScreenHeight == 0)
+			{
+				Graphic.ScreenWidth = Screen.currentResolution.width;
+				Graphic.ScreenHeight = Screen.currentResolution.height;
+			}
 		}
 
 		[Serializable]

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -28,6 +28,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 		private void OnEnable()
 		{
 			_gameSettings = new();
+			SetStartConfig();
 			_jsonFileManager = new();
 		}
 
@@ -47,7 +48,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			return true;
 		}
 
-		public void SetStartConfig()
+		private void SetStartConfig()
 		{
 			SetStartLocale();
 			SetStartResolution();

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -62,7 +62,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			}
 		}
 
-		private void SetStartResolution()
+		private void SetDefaultResolution()
 		{
 			if (Graphic.ScreenWidth == 0 || Graphic.ScreenHeight == 0)
 			{

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -47,7 +47,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			_gameSettings = await _jsonFileManager.ReadAsync<GameSettings>(_jsonFileName);
 		}
 
-		private void SetStartConfig()
+		private void SetDefaultConfiguration()
 		{
 			SetStartLocale();
 			SetStartResolution();

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -53,7 +53,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			SetStartResolution();
 		}
 
-		private void SetStartLocale()
+		private void SetDefaultLocale()
 		{
 			if (Localization.Locale == default)
 			{

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/ScriptableObjects/SettingsSO.cs
@@ -28,7 +28,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 		private void OnEnable()
 		{
 			_gameSettings = new();
-			SetStartConfig();
+			SetDefaultConfiguration();
 			_jsonFileManager = new();
 		}
 
@@ -42,15 +42,15 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem.ScriptableObj
 			var fileExists = await _jsonFileManager.ExistsAsync(_jsonFileName);
 
 			if (!fileExists)
-				return false;
+				return;
 
 			_gameSettings = await _jsonFileManager.ReadAsync<GameSettings>(_jsonFileName);
 		}
 
 		private void SetDefaultConfiguration()
 		{
-			SetStartLocale();
-			SetStartResolution();
+			SetDefaultLocale();
+			SetDefaultResolution();
 		}
 
 		private void SetDefaultLocale()

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/SettingsController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SettingsSystem/SettingsController.cs
@@ -28,8 +28,6 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem
 
 		private void Awake()
 		{
-			SetStartLocale();
-			SetStartResolution();
 			ApplySettings();
 		}
 
@@ -41,23 +39,6 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SettingsSystem
 		private void OnDisable()
 		{
 			GameSettingsChangedEventChannel.Raised -= ApplySettings;
-		}
-
-		private void SetStartLocale()
-		{
-			if (Settings.Localization.Locale == default)
-			{
-				Settings.Localization.Locale = LocalizationSettings.SelectedLocale.Identifier;
-			}
-		}
-
-		private void SetStartResolution()
-		{
-			if (Settings.Graphic.ScreenWidth == 0 || Settings.Graphic.ScreenHeight == 0)
-			{
-				Settings.Graphic.ScreenWidth = Screen.currentResolution.width;
-				Settings.Graphic.ScreenHeight = Screen.currentResolution.height;
-			}
 		}
 
 		private void ApplySettings()


### PR DESCRIPTION
- Standardeinstellungen werden jetzt vom SettingSO selbt übernommen (Aus SettingController verschoben, da auf das SO schon während Init Szene zugegriffen werden kann.)
- SettingSO LoadAsync gibt bool zurück als Erfolgsindikator.
- Falls bei Start des Spiels keine .config Datei vorhanden ist, wird eine erstellt.

Bisher wurden immer die Werte erstmal gespeichert, die bei aufrufen des parameterlosen Konstruktors der GameSettings Klasse erzeugt wurden. Auch die "mutableSettings" die im UI benutzt wurden, haben wohl erstmal mit einem völlig neuem Objekt gearbeitet.

Fixes #420  