### PR TITLE
Eigene Klasse und Extensionsmethode zum konvertieren von floats in strings.

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Extensions/FloatExtensions.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Extensions/FloatExtensions.cs
@@ -1,4 +1,5 @@
 using System;
+using BoundfoxStudios.FairyTaleDefender.Utility;
 using UnityEngine;
 
 namespace BoundfoxStudios.FairyTaleDefender.Extensions
@@ -18,6 +19,12 @@ namespace BoundfoxStudios.FairyTaleDefender.Extensions
 			var roundingMultiplier = Mathf.Pow(10, decimals);
 
 			return Mathf.Round(value * roundingMultiplier) / roundingMultiplier;
+		}
+
+		/// <inheritdoc cref="NumberFormatter.Format"/>
+		public static string Format(this float value, bool keepTrailingDecimalZeros = false, bool useInvariantCulture = false)
+		{
+			return NumberFormatter.Format(value, keepTrailingDecimalZeros, useInvariantCulture);
 		}
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/GameplaySystem/UI/TowerUIController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/GameplaySystem/UI/TowerUIController.cs
@@ -102,13 +102,13 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.GameplaySystem.UI
 			{
 				_statistics.TryAddLazy(StatisticType.Range,
 					() => CreateStatisticDisplay("Range",
-						$"{ballisticWeapon.MinimumRange:0.##}-{ballisticWeapon.MaximumRange:0.##}"));
+						$"{ballisticWeapon.MinimumRange.Format()}-{ballisticWeapon.MaximumRange.Format()}"));
 			}
 
 			_statistics.TryAddLazy(StatisticType.Range,
-				() => CreateStatisticDisplay("Range", definition.Range.ToString("0.##")));
+				() => CreateStatisticDisplay("Range", definition.Range.Format()));
 			_statistics.TryAddLazy(StatisticType.FireRate,
-				() => CreateStatisticDisplay("Fire Rate / s", (1 / definition.FireRateEverySeconds).ToString("0.00")));
+				() => CreateStatisticDisplay("Fire Rate / s", (1 / definition.FireRateEverySeconds).Format(true)));
 			_statistics.TryAddLazy(StatisticType.Angle,
 				() => CreateStatisticDisplay("Angle", definition.AttackAngle.ToString()));
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/TooltipSystem/BuildTowerTooltipDisplay.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/TooltipSystem/BuildTowerTooltipDisplay.cs
@@ -1,6 +1,7 @@
 using BoundfoxStudios.FairyTaleDefender.Common;
 using BoundfoxStudios.FairyTaleDefender.Entities.Weapons.BallisticWeapons.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Entities.Weapons.ScriptableObjects;
+using BoundfoxStudios.FairyTaleDefender.Extensions;
 using TMPro;
 using UnityEngine;
 
@@ -28,14 +29,14 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.TooltipSystem
 			AttackRangeText.text = GetRange(resolvedTooltip.WeaponDefinition);
 
 			// FireRate is every seconds, but we'll show fire rate per seconds to the player.
-			FireRatePerSecondsText.text = (1 / resolvedTooltip.WeaponDefinition.FireRateEverySeconds).ToString("0.00");
+			FireRatePerSecondsText.text = (1 / resolvedTooltip.WeaponDefinition.FireRateEverySeconds).Format(true);
 			AttackAngleText.text = resolvedTooltip.WeaponDefinition.AttackAngle.ToString();
 		}
 
 		private string GetRange(WeaponSO weapon) => weapon switch
 		{
-			BallisticWeaponSO ballisticWeapon => $"{ballisticWeapon.MinimumRange:0.##}-{ballisticWeapon.MaximumRange:0.##}",
-			_ => weapon.Range.ToString("0.##"),
+			BallisticWeaponSO ballisticWeapon => $"{ballisticWeapon.MinimumRange.Format()}-{ballisticWeapon.MaximumRange.Format()}",
+			_ => weapon.Range.Format(),
 		};
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a0fbafeb21e1480b8d15dfcddccee7f6
+timeCreated: 1704641819

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs
@@ -1,4 +1,4 @@
-﻿using System.Globalization;
+using System.Globalization;
 using System.Runtime.CompilerServices;
 using UnityEngine.Localization.Settings;
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs
@@ -1,0 +1,27 @@
+﻿using System.Globalization;
+using System.Runtime.CompilerServices;
+using UnityEngine.Localization.Settings;
+
+namespace BoundfoxStudios.FairyTaleDefender.Utility
+{
+	/// <summary>
+	/// Utility class for converting numbers into strings.
+	/// </summary>
+	public static class NumberFormatter
+	{
+		/// <summary>
+		/// Returns the given <paramref name="value"/> as a string with two decimal places at most.
+		/// </summary>
+		/// <param name="value">The number that should be formatted.</param>
+		/// <param name="keepTrailingDecimalZeros">If true displays last decimals even if they are zero, else they will be omitted if zero.</param>
+		/// <param name="useInvariantCulture">Useful for e.g. testing, as separators aren't system dependent.</param>
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static string Format(float value, bool keepTrailingDecimalZeros = false, bool useInvariantCulture = false)
+		{
+			var culture = useInvariantCulture ? CultureInfo.InvariantCulture : LocalizationSettings.SelectedLocale.Identifier.CultureInfo;
+			var format = keepTrailingDecimalZeros ? "0.00" : "0.##";
+
+			return value.ToString(format, culture);
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Utility/NumberFormatter.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: fd8d1b463af748438e218073a683792e
+timeCreated: 1704641886

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 1d6564e6f26348e6b1d3672d8dc6f7d8
+timeCreated: 1704642997

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility/NumberFormatterTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility/NumberFormatterTests.cs
@@ -1,0 +1,35 @@
+using BoundfoxStudios.FairyTaleDefender.Utility;
+using FluentAssertions;
+using NUnit.Framework;
+
+namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Utility
+{
+	public class NumberFormatterTests
+	{
+		[TestCase(-1.0625f, "-1.06")]
+		public void Format_KeepsOnlyTwoDecimals_GivenALongerNumber(float value, string expectedString)
+		{
+			var result = NumberFormatter.Format(value, useInvariantCulture: true);
+
+			result.Should().Be(expectedString);
+		}
+
+		[TestCase(0.00f, "0")]
+		[TestCase(0.50f, "0.5")]
+		public void Format_OmitsTrailingDecimalsIfZero(float value, string expectedString)
+		{
+			var result = NumberFormatter.Format(value, useInvariantCulture: true);
+
+			result.Should().Be(expectedString);
+		}
+
+		[TestCase(0.00f, "0.00")]
+		[TestCase(0.50f, "0.50")]
+		public void Format_KeepTrailingDecimalZeros_GivenTheyShouldBeDisplayed(float value, string expectedString)
+		{
+			var result = NumberFormatter.Format(value, true, true);
+
+			result.Should().Be(expectedString);
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility/NumberFormatterTests.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Utility/NumberFormatterTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 67adbf7b955240d2bcf571238eb5fe10
+timeCreated: 1704628087

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/BoundfoxStudios.FairyTaleDefender.Tests.asmdef
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/BoundfoxStudios.FairyTaleDefender.Tests.asmdef
@@ -9,7 +9,8 @@
         "Unity.Addressables",
         "Unity.ResourceManager",
         "BoundfoxStudios.FluentAssertions",
-        "BoundfoxStudios.FairyTaleDefender"
+        "BoundfoxStudios.FairyTaleDefender",
+        "Unity.Localization"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 09143e5b216d402696666942462bb982
+timeCreated: 1704636285

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs
@@ -1,0 +1,21 @@
+using FluentAssertions;
+using NUnit.Framework;
+using UnityEngine.Localization.Settings;
+
+namespace BoundfoxStudios.FairyTaleDefender.Tests.Utility
+{
+	public class NumberFormatterTests
+	{
+		[Test]
+		public void Format_DisplaysSeparatorInCurrentCulture()
+		{
+			var value = -1.5f;
+			var culture = LocalizationSettings.SelectedLocale.Identifier.CultureInfo;
+			var expectedResult = value.ToString("0.##", culture);
+
+			var result = FairyTaleDefender.Utility.NumberFormatter.Format(value);
+
+			result.Should().Be(expectedResult);
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 25959188af9e4de4aaf52420299d74c4
+timeCreated: 1704636294


### PR DESCRIPTION
Habe die Funktion sowohl als eigene Klasse, als auch als Extensionmethode implementiert, da ich persönlich an solchen Stellen die Extensions lieber nutze. Kann ich an nutzenden Stellen aber auch gerne ändern.
Apropos - Ich habe mit Rider nach sowas wie "0.00" und "0.##" im Code gesucht, bin mir aber nicht 100% sicher ob ich so alle Stellen erwischt habe. Welchen Editor/Funktionen nutzt du um nach sowas zu suchen?
Zurzeit konvertiere ich auch nur floats, hab nicht die Notwendigkeit für double oder decimal gesehen, kann aber auch gerne nachgeholt werden :)
Was mir noch aufgefallen ist:
- Anzeige von Reichweite eines Turmes ist unterschiedlich auf ausgewähltem Turm der platziert ist, und einem der noch nicht platziert wurde- einmal ohne Nachkommastellen, einmal mit. Kann sogar sein, dass ich dich da schonmal nach gefragt hatte im Gespräch, leider aber keine Notizen dazu gemacht, deswegen sorry :) Sollte das so bleiben, oder haben wir den Issue dafür vergessen zu erstellen?
![grafik](https://github.com/BoundfoxStudios/fairy-tale-defender/assets/18291863/af7964dd-c8eb-41a7-990b-ec934b5aa5a3)

- Naming von Tests inkonsistent:
  - An älteren Stellen nach Muster in etwa Methode_ErwartetesVerhalten_Bedingung
  - An etwas neueren DoesChangeAddRangeDependingOnTheTowersPosition z.B.
In der Doku haben wir das nicht genau festgehalten, vllt noch nachholen, damit ich weiß an welche Konvention ich mich halten soll :P

resolves #404 