### PR TITLE
Namen von Tests anpassen.

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Entities/Weapons/BallisticWeapons/ScriptableObjects/EffectiveBallisticWeaponCalculatorSOTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Entities/Weapons/BallisticWeapons/ScriptableObjects/EffectiveBallisticWeaponCalculatorSOTests.cs
@@ -15,7 +15,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Entities.Weapons.Ballis
 		[TestCase(1, 6)]
 		[TestCase(2, 8)]
 		[TestCase(10, 24)]
-		public void DoesChangeAddRangeDependingOnTheTowersPosition(float towerYPosition, float expectedMaximumRange,
+		public void Calculate_IncreasesMaximumTowerRange_GivenYPositionAboveZero(float towerYPosition, float expectedMaximumRange,
 			float definedMaximumRange = 4, float heightToRangeFactor = 2)
 		{
 			var sut = CreateSystemUnderTest(heightToRangeFactor);

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Events/ScriptableObjects/EventChannelSOTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Events/ScriptableObjects/EventChannelSOTests.cs
@@ -25,7 +25,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Events.ScriptableObject
 		}
 
 		[Test]
-		public void RaiseDoesRaiseTheEvent()
+		public void Raise_DoesRaiseTheEvent()
 		{
 			LogAssert.Expect(LogType.Log, new Regex(@"Event.*?Void Event Channel Test raised"));
 
@@ -60,7 +60,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Events.ScriptableObject
 		}
 
 		[Test]
-		public void RaiseDoesRaiseTheEvent()
+		public void Raise_DoesRaiseTheEvent()
 		{
 			LogAssert.Expect(LogType.Log, new Regex(@"Event.*?Object Event Channel Test raised.*?value.*?Foo=Unit Test, Bar=5"));
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Infrastructure/ScriptableObjectIdentityTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Infrastructure/ScriptableObjectIdentityTests.cs
@@ -7,7 +7,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 	public class ScriptableObjectIdentityTests
 	{
 		[Test]
-		public void ShouldBeEqualIfTheyAreTheSameInstance()
+		public void Equals_ShouldBeTrue_IfTheyAreTheSameInstance()
 		{
 			var identity = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 
@@ -15,7 +15,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 		}
 
 		[Test]
-		public void ShouldBeEqualIfTheyAreDifferentInstancesHavingTheSameGuid()
+		public void Equals_ShouldBeTrue_IfTheyAreDifferentInstancesWithSameGuid()
 		{
 			var identity1 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 			var identity2 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
@@ -24,7 +24,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 		}
 
 		[Test]
-		public void ShouldNotBeEqualIfTheyAreDifferentInstancesHavingDifferentGuid()
+		public void Equals_ShouldNotBeTrue_IfTheyAreDifferentInstancesWithDifferentGuid()
 		{
 			var identity1 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 			var identity2 = new ScriptableObjectIdentity { Guid = "different-unit-test-guid" };
@@ -33,7 +33,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 		}
 
 		[Test]
-		public void ShouldBeEqualIfTheyAreTheSameInstanceComparedWithDoubleEqualOperator()
+		public void CompareWithDoubleEqualOperator_ShouldBeEqual_IfTheyAreTheSameInstance()
 		{
 			var identity = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 
@@ -45,7 +45,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 		}
 
 		[Test]
-		public void ShouldBeEqualIfTheyAreTheDifferentInstancesWithSameGuidComparedWithDoubleEqualOperator()
+		public void CompareWithDoubleEqualOperator_ShouldBeEqual_IfTheyAreDifferentInstancesWithSameGuid()
 		{
 			var identity1 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 			var identity2 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
@@ -54,7 +54,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Infrastructure
 		}
 
 		[Test]
-		public void ShouldNotBeEqualIfTheyAreTheDifferentInstancesWithDifferentGuidComparedWithDoubleEqualOperator()
+		public void CompareWithNotEqualOperator_ShouldNotBeEqual_IfTheyAreDifferentInstancesWithDifferentGuid()
 		{
 			var identity1 = new ScriptableObjectIdentity { Guid = "unit-test-guid" };
 			var identity2 = new ScriptableObjectIdentity { Guid = "different-unit-test-guid" };

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Navigation/PathProviders/SplinePathProviderTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Navigation/PathProviders/SplinePathProviderTests.cs
@@ -19,7 +19,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Navigation.PathProvider
 	public class SplinePathProviderTests
 	{
 		[Test]
-		public void CanSuccessfullyCreateAPathOnASingleSpline()
+		public void CreatePath_CanCreateAPath_GivenASingleSpline()
 		{
 			var splineContainerMock = CreateSplineContainerMock(
 				new[]
@@ -54,7 +54,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Navigation.PathProvider
 		}
 
 		[Test]
-		public void CanSuccessfullyCreateAPathOfTwoSplinesThatSplitTheMainSplineInTheMiddleAndMergeCorrectly()
+		public void CreatePath_CanCreateAPath_GivenTwoSplinesThatSplitTheMainSplineInTheMiddleAndMergeAgain()
 		{
 			var splitKnot = new BezierKnot(new(0, 0, 1));
 			var mergeKnot = new BezierKnot(new(0, 0, 2));
@@ -109,7 +109,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Navigation.PathProvider
 		}
 
 		[Test]
-		public void CanSuccessfullyCreateAPathOfTwoSplinesThatSplitTheMainSplineAtStartAndMergeAtTheEndCorrectly()
+		public void CreatePath_CanCreateAPath_GivenTwoSplinesThatSplitTheMainSplineAtStartAndMergeAtTheEnd()
 		{
 			var splitKnot = new BezierKnot(new(0, 0, 0));
 			var mergeKnot = new BezierKnot(new(0, 0, 3));
@@ -164,7 +164,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Navigation.PathProvider
 		}
 
 		[Test]
-		public void WillFailIfASplineSplitsButNeverMergesBackToTheMainSpline()
+		public void CreatePath_ShouldThrow_IfASplineSplitsButNeverMergesBackToTheMainSpline()
 		{
 			var splitKnot = new BezierKnot(new(0, 0, 1));
 
@@ -225,7 +225,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Editor.Navigation.PathProvider
 		[TestCase(new[] { 1, 0, 0, 0 })] // 1. -> 2. -> 1.
 		[TestCase(new[] { 2, 0 })] // 1. -> 4. -> 1
 		[TestCase(new[] { 1, 1, 0, 0 })] // 1. -> 2. -> 3. -> 1.
-		public void CanSuccessfullyCreateAPath(int[] linkDecisions)
+		public void CreatePath_CanCreateAPath_GivenMultipleSplinesAndLinks(int[] linkDecisions)
 		{
 			var firstLinkKnot = new BezierKnot(0, 0, 1);
 			var secondLinkKnot = new BezierKnot(1, 0, 2);

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Build/BuildManifest/BuildManifestReaderTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Build/BuildManifest/BuildManifestReaderTests.cs
@@ -9,7 +9,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Build.BuildManifest
 	public class BuildManifestReaderTests
 	{
 		[UnityTest]
-		public IEnumerator CanReadBuildManifest() => UniTask.ToCoroutine(async () =>
+		public IEnumerator LoadAsync_CanReadBuildManifest() => UniTask.ToCoroutine(async () =>
 		{
 			var sut = new BuildManifestReader();
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Build/Contributors/ContributorsReaderTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Build/Contributors/ContributorsReaderTests.cs
@@ -9,7 +9,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Build.Contributors
 	public class ContributorsReaderTests
 	{
 		[UnityTest]
-		public IEnumerator CanReadContributors() => UniTask.ToCoroutine(async () =>
+		public IEnumerator LoadAsync_CanReadContributors() => UniTask.ToCoroutine(async () =>
 		{
 			var sut = new ContributorsReader();
 

--- a/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Tests/Runtime/Utility/NumberFormatterTests.cs
@@ -1,3 +1,4 @@
+using BoundfoxStudios.FairyTaleDefender.Utility;
 using FluentAssertions;
 using NUnit.Framework;
 using UnityEngine.Localization.Settings;
@@ -13,7 +14,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Tests.Utility
 			var culture = LocalizationSettings.SelectedLocale.Identifier.CultureInfo;
 			var expectedResult = value.ToString("0.##", culture);
 
-			var result = FairyTaleDefender.Utility.NumberFormatter.Format(value);
+			var result = NumberFormatter.Format(value);
 
 			result.Should().Be(expectedResult);
 		}

--- a/docs/content/docs/docs-technical/coding-conventions/index.md
+++ b/docs/content/docs/docs-technical/coding-conventions/index.md
@@ -146,6 +146,20 @@ Damit es in Unity genutzt werden kann, nutzen wir den [Unity-Adapter](https://gi
 
 Außerdem steht [Moq](https://github.com/moq/moq4) zur Verfügung, um Fake-Objekte zu erzeugen.
 
+##### Benamung
+
+Klassen die Tests enthalten sollten mit dem Suffix `Tests` im Namen enden.
+
+Die einzelnen Testmethoden sollten nach dem Schema `Methode_ErwartetesVerhalten` oder `Methode_ErwartetesVerhalten_Bedingung` bezeichnet werden. Beispiele hierfür wären `ReadAsync_CanReadAFile` oder `ExistsAsync_ReturnsTrue_WhenFileExists`.
+
+> **SUT**: Sut steht für **s**ystem **u**nder **t**est, also das System(Klasse, Methode) welches getestet wird.
+
+##### Aufbau
+
+* Tests sollten möglichst nach dem [AAA](https://learn.microsoft.com/de-de/dotnet/core/testing/unit-testing-best-practices#arranging-your-tests)(Arrange, Act, Assert) Muster aufgebaut werden.
+* Vorzugsweise nur ein Assert pro Test. Damit ist einfacher nachzuvollziehen wieso ein Test scheitert.
+* Weitere Orientierungspunkte für gute Tests wären die [FIRST](https://learn.microsoft.com/de-de/dotnet/core/testing/unit-testing-best-practices#characteristics-of-a-good-unit-test) Prinzipien
+
 ### Formatierung
 
 * Verwende **1 Tab** pro Spalte, keine Leerzeichen.


### PR DESCRIPTION
Dokumentation(Coding conventions): Bezeichnung/ Aufbau von Tests hinzugefügt
Code: Bezeichnung von Testmethoden entsprechend Doku angepasst.

closes #428

Wie soll mit Fällen wie der Extensionmethode hier umgegangen werden? https://github.com/BoundfoxStudios/fairy-tale-defender/blob/01e753a064f9c85dd2fb61833c6d2115bf17179d/FairyTaleDefender/Assets/_Game/Scripts/Tests/Editor/Extensions/BezierKnotExtensions.cs#L9 
Eigentlich ist es ja auch ein Test, sollte man daher hier auch die "neue" Bezeichnung anwenden oder in solchen Fällen eine Ausnahme machen?