### PR TITLE
Dynamischer UI-Aufbau der baubaren Türme

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Prefabs/UI/Buttons/Build_Button.prefab
+++ b/FairyTaleDefender/Assets/_Game/Prefabs/UI/Buttons/Build_Button.prefab
@@ -335,6 +335,8 @@ MonoBehaviour:
     type: 2}
   <Button>k__BackingField: {fileID: 8577549856758770685}
   <CoinDisplay>k__BackingField: {fileID: 5796334138108645846}
+  <Image>k__BackingField: {fileID: 5295773175276684443}
+  <PlayerCoinsController>k__BackingField: {fileID: 0}
   <CoinsChangeEventChannel>k__BackingField: {fileID: 11400000, guid: 42b83e1defef54d16bedaf305ec0489e,
     type: 2}
   <EnterBuildModeEventChannel>k__BackingField: {fileID: 11400000, guid: ba08fca58cb80430883e7a626ae9d678,
@@ -355,19 +357,8 @@ MonoBehaviour:
     type: 2}
   <HideTooltipEventChannel>k__BackingField: {fileID: 11400000, guid: b03109885f5d43a4ba11257465712b62,
     type: 2}
-  <TowerName>k__BackingField:
-    m_TableReference:
-      m_TableCollectionName: 
-    m_TableEntryReference:
-      m_KeyId: 0
-      m_Key: 
-    m_FallbackState: 0
-    m_WaitForCompletion: 0
-    m_LocalVariables: []
   <WeaponDefinition>k__BackingField: {fileID: 0}
-  references:
-    version: 2
-    RefIds: []
+  <TowerDefinition>k__BackingField: {fileID: 0}
 --- !u!1001 &8380350276991179908
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
@@ -2224,6 +2224,7 @@ GameObject:
   - component: {fileID: 1125636244}
   - component: {fileID: 1125636246}
   - component: {fileID: 1125636245}
+  - component: {fileID: 1125636247}
   m_Layer: 5
   m_Name: BuildContainer
   m_TagString: Untagged
@@ -2292,6 +2293,25 @@ MonoBehaviour:
   m_ChildScaleWidth: 0
   m_ChildScaleHeight: 0
   m_ReverseArrangement: 0
+--- !u!114 &1125636247
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1125636243}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7fea80748102403ca9daf68aa319540f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  <BuildButtonPrefab>k__BackingField: {fileID: 8836093814330201621, guid: 7051bfaff63334617b6ba6fcc9e7316f,
+    type: 3}
+  <PlayerCoinsController>k__BackingField: {fileID: 326114872}
+  <AvailableTowers>k__BackingField: {fileID: 11400000, guid: eb21287821faea945b2f9e359eabf15a,
+    type: 2}
+  <AvailableTowersChangedEventChannel>k__BackingField: {fileID: 11400000, guid: 9b83a624ca9ffc4458bccd6687e2213f,
+    type: 2}
 --- !u!1001 &1177097134
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/BallistaTower.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/BallistaTower.asset
@@ -25,6 +25,10 @@ MonoBehaviour:
     type: 3}
   <BlueprintPrefab>k__BackingField: {fileID: 2855513885513437986, guid: 95a2171c951934343b139d736bd2f3a7,
     type: 3}
+  <BuildableIcon>k__BackingField: {fileID: 21300000, guid: d95e37335da724642b80aa4b6adfffe5,
+    type: 3}
+  <WeaponSO>k__BackingField: {fileID: 11400000, guid: fe561347965324f5ab3fae316b5cf944,
+    type: 2}
   <Price>k__BackingField: 10
   references:
     version: 2

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Buildings/Towers/CatapultTower.asset
@@ -25,6 +25,10 @@ MonoBehaviour:
     type: 3}
   <BlueprintPrefab>k__BackingField: {fileID: 9013187241264066330, guid: e9c51145ac61348f0b17f648102a5d9b,
     type: 3}
+  <BuildableIcon>k__BackingField: {fileID: 21300000, guid: 4133520f2c8ad420cba23258ed24aaa7,
+    type: 3}
+  <WeaponSO>k__BackingField: {fileID: 11400000, guid: a75983bad9e3844f4959ba58d440e03a,
+    type: 2}
   <Price>k__BackingField: 10
   references:
     version: 2

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/BuildableTowersRuntimeSetChanged_EventChannel.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/BuildableTowersRuntimeSetChanged_EventChannel.asset
@@ -1,0 +1,17 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 18a2dc5cc80e4c72b774e0a366452ade, type: 3}
+  m_Name: BuildableTowersRuntimeSetChanged_EventChannel
+  m_EditorClassIdentifier: 
+  Description: Raised whenever the set of towers a player can build changes. This
+    will happen e.g. on scene load when available towers are set or the player unlocks
+    a new one.

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/BuildableTowersRuntimeSetChanged_EventChannel.asset.meta
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/BuildableTowersRuntimeSetChanged_EventChannel.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 9b83a624ca9ffc4458bccd6687e2213f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/RuntimeSets/BuildableTower_RuntimeSet.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/RuntimeSets/BuildableTower_RuntimeSet.asset
@@ -12,4 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b0a3df759a6242f982d527dc927bf5eb, type: 3}
   m_Name: BuildableTower_RuntimeSet
   m_EditorClassIdentifier: 
-  <RuntimeSetChangedEventChannel>k__BackingField: {fileID: 0}
+  <RuntimeSetChangedEventChannel>k__BackingField: {fileID: 11400000, guid: 9b83a624ca9ffc4458bccd6687e2213f,
+    type: 2}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Buildings/Towers/ScriptableObjects/BuildableTowerSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Buildings/Towers/ScriptableObjects/BuildableTowerSO.cs
@@ -1,19 +1,27 @@
 using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Entities.Weapons.ScriptableObjects;
 using BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem;
 using UnityEngine;
-using UnityEngine.Localization;
 
 namespace BoundfoxStudios.FairyTaleDefender.Entities.Buildings.Towers.ScriptableObjects
 {
 	[CreateAssetMenu(menuName = Constants.MenuNames.Towers + "/Buildable Tower")]
 	public class BuildableTowerSO : TowerSO, IAmBuildable, IHaveAPrice
 	{
+		[field: Header("References")]
 		[field: SerializeField]
 		public GameObject Prefab { get; private set; } = default!;
 
 		[field: SerializeField]
 		public GameObject BlueprintPrefab { get; private set; } = default!;
 
+		[field: SerializeField]
+		public Sprite BuildableIcon { get; private set; } = default!;
+
+		[field: SerializeField]
+		public WeaponSO WeaponSO { get; private set; } = default!;
+
+		[field: Header("Settings")]
 		[field: SerializeField]
 		[field: Range(1, 1000)]
 		public int Price { get; private set; } = 100;

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Buildings/Towers/ScriptableObjects/BuildableTowerSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Entities/Buildings/Towers/ScriptableObjects/BuildableTowerSO.cs
@@ -6,7 +6,7 @@ using UnityEngine;
 namespace BoundfoxStudios.FairyTaleDefender.Entities.Buildings.Towers.ScriptableObjects
 {
 	[CreateAssetMenu(menuName = Constants.MenuNames.Towers + "/Buildable Tower")]
-	public class BuildableTowerSO : TowerSO, IAmBuildable, IHaveAPrice
+	public class BuildableTowerSO : TowerSO, IAmBuildable, IHaveAPrice, IHaveBuildableUI
 	{
 		[field: Header("References")]
 		[field: SerializeField]

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IAmBuildable.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IAmBuildable.cs
@@ -13,10 +13,5 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem
 		/// A graphics only object used a ghost to show to the player.
 		/// </summary>
 		GameObject BlueprintPrefab { get; }
-
-		/// <summary>
-		/// An image to display in UI e.g. in build buttons.
-		/// </summary>
-		Sprite BuildableIcon { get; }
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IAmBuildable.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IAmBuildable.cs
@@ -13,5 +13,10 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem
 		/// A graphics only object used a ghost to show to the player.
 		/// </summary>
 		GameObject BlueprintPrefab { get; }
+
+		/// <summary>
+		/// An image to display in UI e.g. in build buttons.
+		/// </summary>
+		Sprite BuildableIcon { get; }
 	}
 }

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IHaveBuildableUI.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IHaveBuildableUI.cs
@@ -1,0 +1,12 @@
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem
+{
+	public interface IHaveBuildableUI
+	{
+		/// <summary>
+		/// An image to display in UI e.g. in build buttons.
+		/// </summary>
+		Sprite BuildableIcon { get; }
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IHaveBuildableUI.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/IHaveBuildableUI.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 7e7cef68eac24eddb925714de740cebc
+timeCreated: 1707637029

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/BuildButton.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/BuildButton.cs
@@ -20,6 +20,9 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem.UI
 		private TMP_Text CoinDisplay { get; set; } = default!;
 
 		[field: SerializeField]
+		private Image Image { get; set; } = default!;
+
+		[field: SerializeField]
 		public PlayerCoinsController PlayerCoinsController { get; private set; } = default!;
 
 		[field: Header("Listening Channels")]
@@ -40,6 +43,16 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem.UI
 		private void OnDisable()
 		{
 			CoinsChangeEventChannel.Raised -= CoinsChange;
+		}
+
+		public void Init(T buildable, PlayerCoinsController playerCoinsController)
+		{
+			Buildable = buildable;
+			PlayerCoinsController = playerCoinsController;
+			Image.sprite = buildable.BuildableIcon;
+
+			CoinDisplay.text = Buildable.Price.ToString();
+			SetStateDependingOnCoins();
 		}
 
 		private void CoinsChange(IntDeltaEventChannelSO.EventArgs args)

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/BuildButton.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/BuildButton.cs
@@ -7,7 +7,7 @@ using UnityEngine.UI;
 namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem.UI
 {
 	public abstract class BuildButton<T> : MonoBehaviour
-		where T : IAmBuildable, IHaveAPrice
+		where T : IAmBuildable, IHaveAPrice, IHaveBuildableUI
 	{
 		[field: Header("References")]
 		[field: SerializeField]

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/TowerBuildButtons.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/TowerBuildButtons.cs
@@ -1,0 +1,65 @@
+using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Entities.Buildings.Towers.ScriptableObjects;
+using BoundfoxStudios.FairyTaleDefender.Extensions;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects;
+using BoundfoxStudios.FairyTaleDefender.Infrastructure.RuntimeSets;
+using BoundfoxStudios.FairyTaleDefender.Systems.GameplaySystem;
+using BoundfoxStudios.FairyTaleDefender.Systems.TooltipSystem;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Systems.BuildSystem.UI
+{
+	[AddComponentMenu(Constants.MenuNames.UI + "/" + nameof(TowerBuildButtons))]
+	public class TowerBuildButtons : MonoBehaviour
+	{
+		[field: Header("References")]
+		[field: SerializeField]
+		private GameObject BuildButtonPrefab { get; set; } = default!;
+
+		[field: SerializeField]
+		private PlayerCoinsController PlayerCoinsController { get; set; } = default!;
+
+		[field: SerializeField]
+		private BuildableTowerRuntimeSetSO AvailableTowers { get; set; } = default!;
+
+		[field: Header("Listening Channels")]
+		[field: SerializeField]
+		private VoidEventChannelSO AvailableTowersChangedEventChannel { get; set; } = default!;
+
+		private void OnEnable()
+		{
+			AvailableTowersChangedEventChannel.Raised += AvailableTowersChanged;
+			CreateButtons();
+		}
+
+		private void OnDisable()
+		{
+			AvailableTowersChangedEventChannel.Raised -= AvailableTowersChanged;
+		}
+
+		private void AvailableTowersChanged()
+		{
+			CreateButtons();
+		}
+
+		private void CreateButtons()
+		{
+			transform.ClearChildren();
+
+			foreach (var tower in AvailableTowers.Items)
+			{
+				CreateButton(tower);
+			}
+		}
+
+		private void CreateButton(BuildableTowerSO tower)
+		{
+			var newButtonGameObject = Instantiate(BuildButtonPrefab, transform);
+			var button = newButtonGameObject.GetComponent<TowerBuildButton>();
+			var tooltip = newButtonGameObject.GetComponent<BuildTowerTooltip>();
+
+			button.Init(tower, PlayerCoinsController);
+			tooltip.Init(tower);
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/TowerBuildButtons.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/BuildSystem/UI/TowerBuildButtons.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7fea80748102403ca9daf68aa319540f
+timeCreated: 1707057807

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/TooltipSystem/BuildTowerTooltip.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/TooltipSystem/BuildTowerTooltip.cs
@@ -13,5 +13,11 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.TooltipSystem
 
 		[field: SerializeField]
 		public TowerSO TowerDefinition { get; private set; } = default!;
+
+		public void Init(BuildableTowerSO towerDefinition)
+		{
+			TowerDefinition = towerDefinition;
+			WeaponDefinition = towerDefinition.WeaponSO;
+		}
 	}
 }


### PR DESCRIPTION
Buttons zum Bauen der Türme müssen nicht mehr händisch erstellt werden, wird jetzt automatisch von "TowerBuildButtons" übernommen, sobald ein Level geladen wird bzw. sich die verfügbaren Türme ändern.
Der Einfachheit wegen werden aktuell einfach alle Buttons gelöscht und neu erstellt, ohne zu prüfen ob sie eventuell wieder verwendet werden könnten. 

closes #439 