### PR TITLE
WaveSpawnedEventChannelSO erstellt und mit bisheriger bool Implementation ausgetauscht

### DIFF
--- a/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
+++ b/FairyTaleDefender/Assets/_Game/Scenes/Managers/Gameplay.unity
@@ -1302,7 +1302,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   <SceneReadyEventChannel>k__BackingField: {fileID: 11400000, guid: 3ac76ef19a58741a881c904120fe86a6,
     type: 2}
-  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 209e08c2fac3644e99ab0702be102457,
+  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 1aea3c49e16d89c46a94522c1357ca48,
     type: 2}
   <GameOverEventChannel>k__BackingField: {fileID: 11400000, guid: 10c7057d7409d4925950eabb5fe2816f,
     type: 2}
@@ -3825,7 +3825,7 @@ MonoBehaviour:
     type: 2}
   <EnemySpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: a9b11fb812b052f46aba1307087c9af9,
     type: 2}
-  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 209e08c2fac3644e99ab0702be102457,
+  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 1aea3c49e16d89c46a94522c1357ca48,
     type: 2}
 --- !u!1001 &1683993159
 PrefabInstance:

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/LevelFinished_EventChannel.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/LevelFinished_EventChannel.asset
@@ -12,4 +12,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 07bb1247b08a4ee386b00fc5cd7f7909, type: 3}
   m_Name: LevelFinished_EventChannel
   m_EditorClassIdentifier: 
-  Description: 
+  Description: Raised everytime the gameplay ends, with level won or lost as boolean
+    argument.

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/WaveSpawned_EventChannel.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/WaveSpawned_EventChannel.asset
@@ -9,8 +9,8 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a6e38195d7ec498fbd649eb0ce837ebd, type: 3}
+  m_Script: {fileID: 11500000, guid: d8db536e98204ceab706a1c7d48f1840, type: 3}
   m_Name: WaveSpawned_EventChannel
   m_EditorClassIdentifier: 
-  Description: Raised when a Wave has been spawned. Parameter is true if there are
-    more waves available.
+  Description: Raised when a Wave has been spawned. Has a parameter which indicates
+    if there are more waves available in the current level.

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/WaveSpawned_EventChannel.asset.meta
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Events/Gameplay/WaveSpawned_EventChannel.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 209e08c2fac3644e99ab0702be102457
+guid: 1aea3c49e16d89c46a94522c1357ca48
 NativeFormatImporter:
   externalObjects: {}
   mainObjectFileID: 11400000

--- a/FairyTaleDefender/Assets/_Game/ScriptableObjects/Objectives/SurviveAllWavesObjective.asset
+++ b/FairyTaleDefender/Assets/_Game/ScriptableObjects/Objectives/SurviveAllWavesObjective.asset
@@ -12,12 +12,11 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 24777371a3a34fb49989d68ae92572b5, type: 3}
   m_Name: SurviveAllWavesObjective
   m_EditorClassIdentifier: 
-  <Title>k__BackingField: Reach the last wave and survive all enemies.
   <ObjectiveCompletedEventChannel>k__BackingField: {fileID: 11400000, guid: afe01205a1f439249ba3b2669561f78a,
     type: 2}
   <LivingEnemies>k__BackingField: {fileID: 11400000, guid: 4972058b527553a4dbc326d3ad59bc0c,
     type: 2}
-  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 209e08c2fac3644e99ab0702be102457,
+  <WaveSpawnedEventChannel>k__BackingField: {fileID: 11400000, guid: 1aea3c49e16d89c46a94522c1357ca48,
     type: 2}
   <RuntimeSetChangedEventChannel>k__BackingField: {fileID: 11400000, guid: 365748769eff81e4ab831f3bc9575de3,
     type: 2}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs
@@ -1,0 +1,20 @@
+﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using UnityEngine;
+
+namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects
+{
+	/// <summary>
+	/// Event that is raised whenever a wave has spawned all enemies.
+	/// </summary>
+	/// <remarks>
+	/// Indicates if a level has more waves to spawn in <see cref="EventArgs"/>
+	/// </remarks>
+	[CreateAssetMenu(fileName = "WaveSpawned_EventChannel", menuName = Constants.MenuNames.Events + "/Wave Spawned Event Channel", order = 0)]
+	public class WaveSpawnedEventChannelSO : EventChannelSO<WaveSpawnedEventChannelSO.EventArgs>
+	{
+		public struct EventArgs
+		{
+			public bool LevelHasMoreWaves;
+		}
+	}
+}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs
@@ -1,4 +1,4 @@
-﻿using BoundfoxStudios.FairyTaleDefender.Common;
+using BoundfoxStudios.FairyTaleDefender.Common;
 using UnityEngine;
 
 namespace BoundfoxStudios.FairyTaleDefender.Infrastructure.Events.ScriptableObjects

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs.meta
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Infrastructure/Events/ScriptableObjects/WaveSpawnedEventChannelSO.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: d8db536e98204ceab706a1c7d48f1840
+timeCreated: 1707646285

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/GameplaySystem/GameplayController.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/GameplaySystem/GameplayController.cs
@@ -13,7 +13,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.GameplaySystem
 		private VoidEventChannelSO SceneReadyEventChannel { get; set; } = default!;
 
 		[field: SerializeField]
-		private BoolEventChannelSO WaveSpawnedEventChannel { get; set; } = default!;
+		private WaveSpawnedEventChannelSO WaveSpawnedEventChannel { get; set; } = default!;
 
 		[field: SerializeField]
 		private VoidEventChannelSO GameOverEventChannel { get; set; } = default!;
@@ -65,9 +65,9 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.GameplaySystem
 			});
 		}
 
-		private void WaveSpawned(bool hasMoreWaves)
+		private void WaveSpawned(WaveSpawnedEventChannelSO.EventArgs args)
 		{
-			if (hasMoreWaves)
+			if (args.LevelHasMoreWaves)
 			{
 				SpawnNextWaveEventChannel.Raise();
 			}

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/ObjectiveSystem/ScriptableObjects/SurviveAllWavesObjectiveSO.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/ObjectiveSystem/ScriptableObjects/SurviveAllWavesObjectiveSO.cs
@@ -14,7 +14,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.ObjectiveSystem.ScriptableOb
 
 		[field: Header("Listening Channels")]
 		[field: SerializeField]
-		public BoolEventChannelSO WaveSpawnedEventChannel { get; private set; } = default!;
+		public WaveSpawnedEventChannelSO WaveSpawnedEventChannel { get; private set; } = default!;
 
 		[field: SerializeField]
 		public VoidEventChannelSO RuntimeSetChangedEventChannel { get; private set; } = default!;
@@ -33,9 +33,9 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.ObjectiveSystem.ScriptableOb
 			RuntimeSetChangedEventChannel.Raised -= EnemyRuntimeSetChanged;
 		}
 
-		private void WaveSpawned(bool hasMoreWaves)
+		private void WaveSpawned(WaveSpawnedEventChannelSO.EventArgs args)
 		{
-			_levelHasMoreWaves = hasMoreWaves;
+			_levelHasMoreWaves = args.LevelHasMoreWaves;
 		}
 
 		private void EnemyRuntimeSetChanged()

--- a/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SpawnSystem/WaveSpawner.cs
+++ b/FairyTaleDefender/Assets/_Game/Scripts/Runtime/Systems/SpawnSystem/WaveSpawner.cs
@@ -31,7 +31,7 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SpawnSystem
 		public EnemyEventChannelSO EnemySpawnedEventChannel { get; private set; } = default!;
 
 		[field: SerializeField]
-		private BoolEventChannelSO WaveSpawnedEventChannel { get; set; } = default!;
+		private WaveSpawnedEventChannelSO WaveSpawnedEventChannel { get; set; } = default!;
 
 		private Queue<Wave> _waves = new();
 
@@ -68,7 +68,10 @@ namespace BoundfoxStudios.FairyTaleDefender.Systems.SpawnSystem
 			var spline = pathProvider.CreatePath(WaySplineRuntimeAnchor.ItemSafe, new RandomSplineLinkDecisionMaker());
 			var wave = _waves.Dequeue();
 			await wave.SpawnAsync(spline, WaySplineRuntimeAnchor.ItemSafe, destroyCancellationToken, EnemySpawnedEventChannel);
-			WaveSpawnedEventChannel.Raise(_waves.Count > 0);
+			WaveSpawnedEventChannel.Raise(new()
+			{
+				LevelHasMoreWaves = _waves.Count > 0
+			});
 		}
 	}
 }

--- a/docs/content/docs/docs-technical/systems/event-system/explanation/index.md
+++ b/docs/content/docs/docs-technical/systems/event-system/explanation/index.md
@@ -24,6 +24,43 @@ flowchart LR
     EventListener --> Response["Antwort auf Event"]
 ```
 
+### Event Channel Parameter
+Event Channel mit einem primitiven Datentyp wie Boolean als Parameter sollten vermieden werden, solange aus der Bezeichnung des Event Channel nicht eindeutig hervorgeht wofür der Parameter steht.
+
+So wäre beispielsweise bei ToggleLoadingScreen als Event Channel mit einer bool'schen Variablen offensichtlich wofür diese benutzt wird.
+Bei WaveSpawned mit bool als Parameter hingegen müsste man aus dem Code heraus rückfolgern wie die Variable verwendet wird, oder es wurde eine Beschreibung im Inspektor angelegt, welche jedoch auch "umständlich" zu suchen wäre.
+
+Eine schönere Lösung ist es einen eigenen Typ für die Parameter des Event Channel anzulegen, der die Absicht der Variablen genau beschreibt, womit die Verwendung im Code eindeutiger ist.
+Als Beispiel:
+
+```cs
+//Definition
+public class LevelFinishedEventChannelSO : EventChannelSO<LevelFinishedEventChannelSO.EventArgs>
+{
+	public struct EventArgs
+	{
+		public bool PlayerHasWon;
+	}
+}
+
+//Triggern des Events
+private void LevelFinished()
+{
+	LevelFinishedEventChannel.Raise(new()
+    {
+        PlayerHasWon = false
+    });
+}
+
+//Auf Event reagieren
+private void InitDisplay(LevelFinishedEventChannelSO.EventArgs args)
+{
+    SetLevelFinishedText(args.PlayerHasWon);
+    SetupButtons();
+    ActivateCanvases();
+}
+```
+
 ## Was ist ein Event-System?
 
 Der Sinn eines Event-Systems ist es, Systeme zu entkoppeln.


### PR DESCRIPTION
Eigenen EventChannel Typ erstellt für das Spawnen von Wellen, da dieser mit benannten Variablen aussagekräftiger ist als ein einfacher bool EventChannel.
Dokumentation zur Implementierung wurde um solche Fälle erweitert.

closes #466